### PR TITLE
Grid-196 Generate aggregate layer: flame length max

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3272,6 +3272,16 @@ or false:
         (m/add! (nth (seq burn-count-matrix) band) filtered-fire-spread)))
     (m/add! burn-count-matrix fire-spread-matrix)))
 
+(defn process-aggregate-output-layers!
+  [{:keys [output-burn-probability burn-count-matrix flame-length-sum-matrix
+           flame-length-max-matrix]} fire-spread-results]
+  (when-let [timestep output-burn-probability]
+    (process-burn-count! fire-spread-results burn-count-matrix timestep))
+  (when flame-length-sum-matrix
+    (m/add! flame-length-sum-matrix (:flame-length-matrix fire-spread-results)))
+  (when flame-length-max-matrix
+    (m/emap! #(max %1 %2) flame-length-max-matrix (:flame-length-matrix fire-spread-results))))
+
 (defn initialize-burn-count-matrix
   [output-burn-probability max-runtimes num-rows num-cols]
   (when output-burn-probability
@@ -3413,9 +3423,11 @@ or false:
     (assoc inputs :ignitable-sites ignitable-sites)))
 
 (defn initialize-aggregate-matrices
-  [{:keys [max-runtimes num-rows num-cols output-burn-probability output-flame-length-sum]}]
+  [{:keys [max-runtimes num-rows num-cols output-burn-probability output-flame-length-sum
+           output-flame-length-max]}]
   {:burn-count-matrix       (initialize-burn-count-matrix output-burn-probability max-runtimes num-rows num-cols)
-   :flame-length-sum-matrix (when output-flame-length-sum (m/zero-array [num-rows num-cols]))})
+   :flame-length-sum-matrix (when output-flame-length-sum (m/zero-array [num-rows num-cols]))
+   :flame-length-max-matrix (when output-flame-length-max (m/zero-array [num-rows num-cols]))})
 
 (defn add-aggregate-matrices
   [inputs]
@@ -3439,10 +3451,10 @@ or false:
 ;;        initial-ignition-site calculation into input-variations or
 ;;        move it to run-fire-spread.
 (defn run-simulation!
-  [{:keys [output-csvs? output-burn-probability envelope ignition-layer cell-size
+  [{:keys [output-csvs? envelope ignition-layer cell-size
            max-runtimes ignition-rows ignition-cols foliar-moistures ellipse-adjustment-factors perturbations
            temperatures relative-humidities wind-speeds-20ft wind-from-directions
-           random-seed ignition-start-times flame-length-sum-matrix burn-count-matrix] :as inputs}
+           random-seed ignition-start-times] :as inputs}
    i]
   (tufte/profile
    {:id :run-simulation}
@@ -3467,10 +3479,7 @@ or false:
                                                 {:initial-ignition-site initial-ignition-site})))]
      (when fire-spread-results
        (process-output-layers! inputs fire-spread-results envelope i)
-       (when-let [timestep output-burn-probability]
-         (process-burn-count! fire-spread-results burn-count-matrix timestep))
-       (when flame-length-sum-matrix
-        (m/add! flame-length-sum-matrix (:flame-length-matrix fire-spread-results)))
+       (process-aggregate-output-layers! inputs fire-spread-results)
        (process-binary-output! inputs fire-spread-results i))
      (when output-csvs?
        (merge
@@ -3513,6 +3522,7 @@ or false:
          :truncate? false)
     {:burn-count-matrix       (:burn-count-matrix inputs)
      :flame-length-sum-matrix (:flame-length-sum-matrix inputs)
+     :flame-length-max-matrix (:flame-length-max-matrix inputs)
      :summary-stats           summary-stats}))
 
 ;;-----------------------------------------------------------------------------
@@ -3546,6 +3556,18 @@ or false:
    {:keys [flame-length-sum-matrix]}]
   (when output-flame-length-sum
     (output-geotiff inputs flame-length-sum-matrix "flame_length_sum" envelope)))
+
+(defn write-flame-length-max-layer!
+  [{:keys [envelope output-flame-length-max] :as inputs}
+   {:keys [flame-length-max-matrix]}]
+  (when output-flame-length-max
+    (output-geotiff inputs flame-length-max-matrix "flame_length_max" envelope)))
+
+(defn write-aggregate-layers!
+  [inputs outputs]
+  (write-burn-probability-layer! inputs outputs)
+  (write-flame-length-sum-layer! inputs outputs)
+  (write-flame-length-max-layer! inputs outputs))
 
 (defn write-csv-outputs!
   [{:keys [output-csvs? output-directory outfile-suffix]} {:keys [summary-stats]}]
@@ -3591,8 +3613,7 @@ or false:
       (if (seq (:ignitable-sites inputs))
         (let [outputs (run-simulations! inputs)]
           (write-landfire-layers! inputs)
-          (write-burn-probability-layer! inputs outputs)
-          (write-flame-length-sum-layer! inputs outputs)
+          (write-aggregate-layers! inputs outputs)
           (write-csv-outputs! inputs outputs))
         (log-str "Could not run simulation. No valid ignition sites")))))
 #+end_src
@@ -4254,7 +4275,7 @@ of simulations, include the following mapping:
 {:output-burn-probability 10}
 #+end_src
 
-To specify the output of the flame length sum layers, 
+To specify the output of the flame length sum layer, 
 which is the sum of flame lengths across simulations, include
 the following mapping:
 
@@ -4262,6 +4283,16 @@ the following mapping:
 
 #+begin_src clojure
 {:output-flame-length-sum true}
+#+end_src
+
+To specify the output of the flame length max layer, 
+which is the max of flame lengths across simulations, include
+the following mapping:
+
+- *output-*flame-length-max*: bolean
+
+#+begin_src clojure
+{:output-flame-length-max true}
 #+end_src
 
 Other output mappings:

--- a/test/gridfire/output_test.clj
+++ b/test/gridfire/output_test.clj
@@ -72,3 +72,10 @@
         _      (process-config-file! config)]
 
     (is (.exists (io/file "test/output/flame_length_sum.tif")))))
+
+(deftest output_flame_length_max_test
+  (let [config (merge test-config-base
+                      {:output-flame-length-max true})
+        _      (process-config-file! config)]
+
+    (is (.exists (io/file "test/output/flame_length_max.tif")))))


### PR DESCRIPTION
## Purpose

Add support for generating flame length max output layer, where each
cell is the max flame length across all simulation ensemble members.

This will produce flame_length_max.tif when the right option is
specified in the config file.

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g.
      `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing

1. run test on ns `gridfire.output-test`