### PR TITLE
GRID-198 Generate aggregate layer: burn count

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3283,8 +3283,8 @@ or false:
     (m/emap! #(max %1 %2) flame-length-max-matrix (:flame-length-matrix fire-spread-results))))
 
 (defn initialize-burn-count-matrix
-  [output-burn-probability max-runtimes num-rows num-cols]
-  (when output-burn-probability
+  [{:keys [output-burn-probability output-burn-count max-runtimes num-rows num-cols]}]
+  (when (or output-burn-count output-burn-probability)
     (if (int? output-burn-probability)
       (let [num-bands (inc (quot (apply max max-runtimes) output-burn-probability))]
         (m/zero-array [num-bands num-rows num-cols]))
@@ -3423,9 +3423,9 @@ or false:
     (assoc inputs :ignitable-sites ignitable-sites)))
 
 (defn initialize-aggregate-matrices
-  [{:keys [max-runtimes num-rows num-cols output-burn-probability output-flame-length-sum
-           output-flame-length-max]}]
-  {:burn-count-matrix       (initialize-burn-count-matrix output-burn-probability max-runtimes num-rows num-cols)
+  [{:keys [num-rows num-cols output-flame-length-sum
+           output-flame-length-max] :as inputs}]
+  {:burn-count-matrix       (initialize-burn-count-matrix inputs)
    :flame-length-sum-matrix (when output-flame-length-sum (m/zero-array [num-rows num-cols]))
    :flame-length-max-matrix (when output-flame-length-max (m/zero-array [num-rows num-cols]))})
 
@@ -3563,11 +3563,18 @@ or false:
   (when output-flame-length-max
     (output-geotiff inputs flame-length-max-matrix "flame_length_max" envelope)))
 
+(defn write-burn-count-layer!
+  [{:keys [envelope output-burn-count] :as inputs}
+   {:keys [burn-count-matrix]}]
+  (when output-burn-count
+    (output-geotiff inputs burn-count-matrix "burn_count" envelope)))
+
 (defn write-aggregate-layers!
   [inputs outputs]
   (write-burn-probability-layer! inputs outputs)
   (write-flame-length-sum-layer! inputs outputs)
-  (write-flame-length-max-layer! inputs outputs))
+  (write-flame-length-max-layer! inputs outputs)
+  (write-burn-count-layer! inputs outputs))
 
 (defn write-csv-outputs!
   [{:keys [output-csvs? output-directory outfile-suffix]} {:keys [summary-stats]}]
@@ -4275,7 +4282,7 @@ of simulations, include the following mapping:
 {:output-burn-probability 10}
 #+end_src
 
-To specify the output of the flame length sum layer, 
+To specify the output of the flame length sum layer,
 which is the sum of flame lengths across simulations, include
 the following mapping:
 
@@ -4285,7 +4292,7 @@ the following mapping:
 {:output-flame-length-sum true}
 #+end_src
 
-To specify the output of the flame length max layer, 
+To specify the output of the flame length max layer,
 which is the max of flame lengths across simulations, include
 the following mapping:
 
@@ -4293,6 +4300,16 @@ the following mapping:
 
 #+begin_src clojure
 {:output-flame-length-max true}
+#+end_src
+
+To specify the output of the burn count layer, which is the number of
+times a cell has burned across simulations, include the following
+mapping:
+
+- *output-*burn-count*: bolean
+
+#+begin_src clojure
+{:output-burn-count true}
 #+end_src
 
 Other output mappings:

--- a/test/gridfire/output_test.clj
+++ b/test/gridfire/output_test.clj
@@ -79,3 +79,10 @@
         _      (process-config-file! config)]
 
     (is (.exists (io/file "test/output/flame_length_max.tif")))))
+
+(deftest output_burn_count_test
+  (let [config (merge test-config-base
+                      {:output-burn-count true})
+        _      (process-config-file! config)]
+
+    (is (.exists (io/file "test/output/burn_count.tif")))))


### PR DESCRIPTION
-------

## Purpose

Add support for generating burn count output layer, where each sell is
the sum of burn occurrences across simulations

This will produce burn_count.tif when the right option is specified in
the config file.

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g.
      `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing

1. run test on ns `gridfire.output-test`