### PR TITLE
GRID-240 fix foliar-moisture unit in crown fire equation

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -1381,11 +1381,11 @@ crown fire initiation occurs.
 (defn van-wagner-crown-fire-initiation?
   "- canopy-cover (0-100 %)
    - canopy-base-height (ft)
-   - foliar-moisture (lb moisture/lb ovendry weight)
+   - foliar-moisture (0-100 %) (lb moisture/lb ovendry weight)
    - fire-line-intensity (Btu/ft*s)"
   [^double canopy-cover ^double canopy-base-height ^double foliar-moisture ^double fire-line-intensity]
   (and (> canopy-cover 40.0)
-       (-> (+ 460.0 (* 2600.0 foliar-moisture)) ;; heat-of-ignition = kJ/kg
+       (-> (+ 460.0 (* 26.0 foliar-moisture)) ;; heat-of-ignition = kJ/kg
            (* 0.01 (convert/ft->m canopy-base-height))
            (Math/pow 1.5) ;; critical-intensity = kW/m
            (convert/kW-m->Btu-ft-s)

--- a/src/gridfire/crown_fire.clj
+++ b/src/gridfire/crown_fire.clj
@@ -5,11 +5,11 @@
 (defn van-wagner-crown-fire-initiation?
   "- canopy-cover (0-100 %)
    - canopy-base-height (ft)
-   - foliar-moisture (lb moisture/lb ovendry weight)
+   - foliar-moisture (0-100 %) (lb moisture/lb ovendry weight)
    - fire-line-intensity (Btu/ft*s)"
   [^double canopy-cover ^double canopy-base-height ^double foliar-moisture ^double fire-line-intensity]
   (and (> canopy-cover 40.0)
-       (-> (+ 460.0 (* 2600.0 foliar-moisture)) ;; heat-of-ignition = kJ/kg
+       (-> (+ 460.0 (* 26.0 foliar-moisture)) ;; heat-of-ignition = kJ/kg
            (* 0.01 (convert/ft->m canopy-base-height))
            (Math/pow 1.5) ;; critical-intensity = kW/m
            (convert/kW-m->Btu-ft-s)


### PR DESCRIPTION
-------

## Purpose
Foliar moisture comes in as percent (0-100) but is incorrectly
converted to decimal in van-wagner-crown-fire-initiation?

## Related Issues
Closes GRID-240

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
clojure -M:test