### PR TITLE
GRID-246 fix slope conversion to be percent instead of radians

### DIFF
--- a/src/gridfire/conversion.clj
+++ b/src/gridfire/conversion.clj
@@ -46,6 +46,12 @@
   [^double degrees]
   (* degrees 0.017453292519943295)) ; (/ Math/PI 180.0) = 0.017453292519943295
 
+(defn deg->percent
+  "Convert degrees to percent."
+  ^double
+  [^double degrees]
+  (Math/tan (deg->rad degrees)))
+
 (defn rad->deg
   "Convert radians to degrees."
   ^double
@@ -192,7 +198,7 @@
 
 (def conversion-table
   {:elevation          {:metric m->ft}
-   :slope              {nil deg->rad}
+   :slope              {nil deg->percent}
    :canopy-height      {:metric m->ft}
    :canopy-base-height {:metric m->ft}
    :crown-bulk-density {:metric kg-m3->lb-ft3}


### PR DESCRIPTION
-------

## Purpose
Slope should be in percent instead of radians

## Related Issues
Closes GRID-246

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)