### PR TITLE
GRID-239 Add Crown Fire tests

### DIFF
--- a/src/gridfire/conversion.clj
+++ b/src/gridfire/conversion.clj
@@ -101,16 +101,16 @@
   (* km-hr 0.621371192237334))
 
 (defn wind-speed-20ft->wind-speed-10m
-  "Convert wind speed at 20ft (mph) to wind speed at 10m (km/hr)"
+  "Convert wind speed at 20ft to wind speed at 10m."
   ^double
   [^double wind-speed-20ft]
-  (/ (mph->km-hr wind-speed-20ft) 0.87))
+  (/ wind-speed-20ft 0.87))
 
 (defn wind-speed-10m->wind-speed-20ft
-  "Convert wind speed at 10m (km/hr) to wind speed at 20ft (mph)"
+  "Convert wind speed at 10m to wind speed at 20ft."
   ^double
   [^double wind-speed-10m]
-  (km-hr->mph (* 0.87 wind-speed-10m)))
+  (* 0.87 wind-speed-10m))
 
 (defn Btu-ft-s->kW-m
   "Convert BTU per feet per second to kilowatt per meter."

--- a/src/gridfire/crown_fire.clj
+++ b/src/gridfire/crown_fire.clj
@@ -2,10 +2,12 @@
 (ns gridfire.crown-fire
   (:require [gridfire.conversion :as convert]))
 
+(set! *unchecked-math* :warn-on-boxed)
+
 (defn van-wagner-critical-fire-line-intensity
-  "Ouputs the critical fire-line intensity (kW/m) using:
+  "Ouputs the critical fire line intensity (kW/m) using:
    - canopy-base-height (m)
-   - foliar-moisture (%)"
+   - foliar-moisture (0-100 %)"
   ^double
   [^double canopy-base-height ^double foliar-moisture]
   (-> foliar-moisture
@@ -18,7 +20,7 @@
 (defn van-wagner-crown-fire-initiation-metric?
   "- canopy-cover (0-100 %)
    - canopy-base-height (m)
-   - foliar-moisture (0-100 %) (lb moisture/lb ovendry weight)
+   - foliar-moisture (0-100 %)
    - fire-line-intensity (kW/m)"
   [^double canopy-cover ^double canopy-base-height ^double foliar-moisture ^double fire-line-intensity]
   (and (> canopy-cover 40.0)
@@ -29,7 +31,7 @@
 (defn van-wagner-crown-fire-initiation?
   "- canopy-cover (0-100 %)
    - canopy-base-height (ft)
-   - foliar-moisture (lb moisture/lb ovendry weight)
+   - foliar-moisture (0-100 %)
    - fire-line-intensity (Btu/ft*s)"
   [^double canopy-cover ^double canopy-base-height ^double foliar-moisture ^double fire-line-intensity]
   (van-wagner-crown-fire-initiation-metric? canopy-cover
@@ -39,10 +41,9 @@
 ;; van-wagner-crown-fire-initiation ends here
 
 ;; [[file:../../org/GridFire.org::cruz-crown-fire-spread][cruz-crown-fire-spread]]
-
 (defn cruz-active-crown-fire-spread
   "Returns active spread-rate in m/min given:
-   - wind-speed-10m (km/h)
+   - wind-speed-10m (km/hr)
    - crown-bulk-density (kg/m^3)
    - estimated-fine-fuel-moisture (0-100 %)"
   ^double
@@ -53,10 +54,9 @@
      (Math/exp (* -0.17 estimated-fine-fuel-moisture))))
 
 (defn cruz-passive-crown-fire-spread
-  "Returns the passive spread-rate in m/min given:
-   - wind-speed-10m (km/h)
-   - crown-bulk-density (kg/m^3)
-   - estimated-fine-fuel-moisture (0-100 %)"
+  "Returns passive spread-rate in m/min given:
+   - active-spread-rate (m/min)
+   - critical-spread-rate (m/min)"
   ^double
   [^double active-spread-rate ^double critical-spread-rate]
   (* active-spread-rate
@@ -66,7 +66,7 @@
   "Returns spread-rate in m/min given:
    - wind-speed-10m (km/hr)
    - crown-bulk-density (kg/m^3)
-   - estimated-fine-fuel-moisture (-> M_f :dead :1hr) (0-100+ %)"
+   - estimated-fine-fuel-moisture (-> M_f :dead :1hr) (0-100 %)"
   [^double wind-speed-10m ^double crown-bulk-density ^double estimated-fine-fuel-moisture]
   (let [active-spread-rate   (cruz-active-crown-fire-spread wind-speed-10m
                                                             crown-bulk-density
@@ -82,56 +82,70 @@
    - crown-bulk-density (lb/ft^3)
    - estimated-fine-fuel-moisture (-> M_f :dead :1hr) (0-1)"
   [^double wind-speed-20ft ^double crown-bulk-density ^double estimated-fine-fuel-moisture]
-  (let [[fire-type fire-rate] (cruz-crown-fire-spread-metric (convert/wind-speed-20ft->wind-speed-10m wind-speed-20ft)
-                                                             (convert/lb-ft3->kg-m3 crown-bulk-density)
-                                                             (convert/dec->percent estimated-fine-fuel-moisture))]
+  (let [[fire-type fire-rate] (cruz-crown-fire-spread-metric
+                                (-> wind-speed-20ft (convert/mph->km-hr) (convert/wind-speed-20ft->wind-speed-10m))
+                                (convert/lb-ft3->kg-m3 crown-bulk-density)
+                                (convert/dec->percent estimated-fine-fuel-moisture))]
     [fire-type (convert/m->ft fire-rate)]))
 ;; cruz-crown-fire-spread ends here
 
 ;; [[file:../../org/GridFire.org::crown-fire-line-intensity][crown-fire-line-intensity]]
 ;; heat of combustion is h from the fuel models (generally 8000 Btu/lb)
 (defn crown-fire-line-intensity
-  "Returns Fire Line intensity in Btu/ft/s OR kW/m, given:
+  "Returns the crown fire line intensity in Btu/ft*s OR kW/m, given:
    - crown spread rate (ft/min OR m/min)
    - crown bulk density (lb/ft^3 OR kg/m^3)
    - canopy height difference (canopy height - canopy base height) (ft OR m)
-   - heat of combustion (Btu/lb^2 OR kJ/kg)
+   - heat of combustion (Btu/lb OR kJ/kg)
 
    (ft/min * lb/ft^3 * ft * Btu/lb)/60 = (Btu/ft*min)/60 = Btu/ft*s
    OR
    (m/min * kg/m^3 * m * kJ/kg)/60 = (kJ/m*min)/60 = kJ/m*s = kW/m"
   ^double
   [^double crown-spread-rate ^double crown-bulk-density ^double canopy-height-difference ^double heat-of-combustion]
-  (/ (* crown-spread-rate
-        crown-bulk-density
-        canopy-height-difference
-        heat-of-combustion)
-     60.0))
+  (-> crown-spread-rate
+      (* crown-bulk-density)
+      (* canopy-height-difference)
+      (* heat-of-combustion)
+      (/ 60.0)))
 
-(defn crown-fire-line-intensity-elmfire ;; kW/m
+(defn crown-fire-line-intensity-elmfire
   "Returns the crown fire line intensity in kW/m, given:
-  - surface-fire-line-intensity (kW/m)
-  - crown-spread-rate (ft/min)
-  - crown-bulk-density (kg/m^3)
-  - canopy height difference (canopy height - canopy base height) (m)
-  - heat of combustion (kJ/kg) <-- Set to a constant of 18,000 kJ/kg.
+   - surface-fire-line-intensity (kW/m)
+   - crown-spread-rate (ft/min)
+   - crown-bulk-density (kg/m^3)
+   - canopy height difference (canopy height - canopy base height) (m)
+   - heat of combustion (kJ/kg) <-- Set to a constant of 18,000 kJ/kg.
 
-  kW/m + (m/min * kg/m^3 * m * kJ/kg)/60 = kW/m + (kJ/m*min)/60 = kW/m +
-  kJ/m*s = kW/m + kW/m = kW/m"
-  ^:double
+   kW/m + (m/min * kg/m^3 * m * kJ/kg)/60 = kW/m + (kJ/m*min)/60 = kW/m + kJ/m*s = kW/m + kW/m = kW/m"
+  ^double
   [^double surface-fire-line-intensity ^double crown-spread-rate ^double crown-bulk-density ^double canopy-height-difference]
   (+ surface-fire-line-intensity
      (crown-fire-line-intensity
        (convert/ft->m crown-spread-rate) ;; m/min
        crown-bulk-density
        canopy-height-difference
-       18000.0)))
+       18000.0))) ;; kJ/kg
 ;; crown-fire-line-intensity ends here
 
 ;; [[file:../../org/GridFire.org::crown-eccentricity][crown-eccentricity]]
+(defn crown-length-to-width-ratio
+  "Calculate the length-to-width ratio of the crown fire front using eq. 9 from
+   Rothermel 1991 given:
+   - wind-speed-20ft (mph)
+   - ellipse-adjustment-factor (dimensionless, < 1.0 circular, > 1.0 elliptical)
+
+   L/W = 1 + 0.125 * U20_mph * EAF"
+  ^double
+  [^double wind-speed-20ft ^double ellipse-adjustment-factor]
+  (-> 0.125
+      (* wind-speed-20ft)
+      (* ellipse-adjustment-factor)
+      (+ 1.0)))
+
 (defn crown-fire-eccentricity
-  "Calculate the eccentricity (E) of crown-fire front using eq. 9 from Rothermel 1991,
-   and eq. 8 from Albini and Chase 1980 given:
+  "Calculate the eccentricity (E) of the crown fire front using eq. 9 from
+   Rothermel 1991, and eq. 8 from Albini and Chase 1980 given:
    - wind-speed-20ft (mph)
    - ellipse-adjustment-factor (dimensionless, < 1.0 circular, > 1.0 elliptical)
 
@@ -139,11 +153,12 @@
    E = sqrt( L/W^2 - 1 ) / L/W"
   ^double
   [^double wind-speed-20ft ^double ellipse-adjustment-factor]
-  (let [length-width-ratio (+ 1.0 (* 0.125
-                                     wind-speed-20ft
-                                     ellipse-adjustment-factor))]
-    (/ (Math/sqrt (- (Math/pow length-width-ratio 2.0) 1.0))
-       length-width-ratio)))
+  (let [length-width-ratio (crown-length-to-width-ratio wind-speed-20ft ellipse-adjustment-factor)]
+    (-> length-width-ratio
+        (Math/pow 2.0)
+        (- 1.0)
+        (Math/sqrt)
+        (/ length-width-ratio))))
 
 (defn elmfire-length-to-width-ratio
   "true/false mph int>0 ft/min

--- a/test/gridfire/crown_fire_test.clj
+++ b/test/gridfire/crown_fire_test.clj
@@ -3,6 +3,7 @@
             [gridfire.conversion :as c]
             [gridfire.crown-fire :refer [crown-fire-line-intensity
                                          crown-fire-eccentricity
+                                         crown-length-to-width-ratio
                                          cruz-crown-fire-spread
                                          cruz-crown-fire-spread-metric
                                          cruz-active-crown-fire-spread
@@ -88,14 +89,14 @@
   (testing "Testing using imperial units fires."
     (are [expected args] (crown-fire-within-5%? [:active-crown expected] (apply cruz-crown-fire-spread args))
          ; ft/min       [wind-speed-20ft (mph) canopy-bulk-density (lb/ft^3) est. fine fuel moisture (0-1)]
-         (c/m->ft 22.6) [(c/wind-speed-10m->wind-speed-20ft 15.8) (c/kg-m3->lb-ft3 0.27) 0.088]
-         (c/m->ft 32.0) [(c/wind-speed-10m->wind-speed-20ft 35.0) (c/kg-m3->lb-ft3 0.1)  0.1]))
+         (c/m->ft 22.6) [(-> 15.8 (c/km-hr->mph) (c/wind-speed-10m->wind-speed-20ft)) (c/kg-m3->lb-ft3 0.27) 0.088]
+         (c/m->ft 32.0) [(-> 35.0 (c/km-hr->mph) (c/wind-speed-10m->wind-speed-20ft)) (c/kg-m3->lb-ft3 0.1)  0.1]))
 
   (testing "Passive crown fires"
     (are [expected args] (crown-fire-within-5%? [:passive-crown expected] (apply cruz-crown-fire-spread args))
          ; ft/min       [wind-speed-20ft (mph) canopy-bulk-density (lb/ft^3) est. fine fuel moisture (0-1)]
-         (c/m->ft 7.6)  [(c/wind-speed-10m->wind-speed-20ft 7.0)  (c/kg-m3->lb-ft3 0.08) 0.08]
-         (c/m->ft 11.0) [(c/wind-speed-10m->wind-speed-20ft 30.0) (c/kg-m3->lb-ft3 0.1)  0.1])))
+         (c/m->ft 7.6)  [(-> 7.0  (c/km-hr->mph) (c/wind-speed-10m->wind-speed-20ft)) (c/kg-m3->lb-ft3 0.08) 0.08]
+         (c/m->ft 11.0) [(-> 30.0 (c/km-hr->mph) (c/wind-speed-10m->wind-speed-20ft)) (c/kg-m3->lb-ft3 0.1)  0.1])))
 
 (deftest ^:unit test-crown-fire-line-intensity
   (testing "Crown Fire line intensity using SI units."
@@ -107,6 +108,15 @@
     (are [expected args] (within-5%? expected (apply crown-fire-line-intensity args))
          ; Btu/ft*s  [crown-spread-rate (f/min) crown-bulk-density (lb/ft^3) canopy-height-difference (ft) heat-of-combustion (Btu/lb)]
          22 [(c/m->ft 1.0) (c/kg-m3->lb-ft3 0.25) (c/m->ft 1.0) 8000.0])))
+
+(deftest ^:unit test-crown-length-to-width-ratio
+  (testing "Crown fire length/width ratio"
+    (are [expected args] (within-5%? expected (apply crown-length-to-width-ratio args))
+         ; L/W [wind-speed-20ft ellipse-adjustment-factor]
+         1.0   [0 0]
+         1.0   [1 0]
+         1.125 [1 1]
+         1.25  [1 2])))
 
 (deftest ^:unit test-crown-fire-eccentricity
   (testing "Crown fire eccentricity"


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds Crown Fire testing using data from Van Wagner 1979 / Cruz 2005 papers.

Some additions:
* New conversion methods (`U-10ft<->U-20m`, `Btu-lb<->kJ-kg`)
* Separated out Van Wagner/Cruz functions into pure SI unit functions to simplify testing.

## Related Issues
Closes GRID-239

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
`clj -M:test-unit`
