### PR TITLE
GRID-273 add jvm-opts MaxRamPercentage

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -22,7 +22,8 @@
 
  :aliases {:build-test-db     {:extra-paths ["test"]
                                :main-opts   ["-m" "gridfire.build-test-db"]}
-           :run               {:main-opts ["-m" "gridfire.cli"]}
+           :run               {:main-opts ["-m" "gridfire.cli"]
+                               :jvm-opts  ["-XX:MaxRAMPercentage=90"]}
            :repl              {:main-opts ["-e" "(require,'gridfire.core)"
                                            "-e" "(in-ns,'gridfire.core)"
                                            "-r"]}

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -122,7 +122,8 @@ deps.edn for the current GridFire version is shown below.
 
  :aliases {:build-test-db     {:extra-paths ["test"]
                                :main-opts   ["-m" "gridfire.build-test-db"]}
-           :run               {:main-opts ["-m" "gridfire.cli"]}
+           :run               {:main-opts ["-m" "gridfire.cli"]
+                               :jvm-opts  ["-XX:MaxRAMPercentage=90"]}
            :repl              {:main-opts ["-e" "(require,'gridfire.core)"
                                            "-e" "(in-ns,'gridfire.core)"
                                            "-r"]}
@@ -149,6 +150,13 @@ deps.edn for the current GridFire version is shown below.
                                               :sha     "dd6da11611eeb87f08780a30ac8ea6012d4c05ce"}}
                                :main-opts   ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"
                                              "-m" "cognitect.test-runner"]}
+           :test-unit         {:extra-paths ["test"]
+                               :extra-deps  {com.cognitect/test-runner
+                                             {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                              :sha     "dd6da11611eeb87f08780a30ac8ea6012d4c05ce"}}
+                               :main-opts   ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"
+                                             "-m" "cognitect.test-runner"
+                                             "--include" ":unit"]}
            :check-reflections {:extra-paths ["test"]
                                :main-opts   ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"
                                              "-e" "(require,'gridfire.cli)"


### PR DESCRIPTION
-------

## Purpose

Adding jvm options to choose a Ram size dependent on a percentage of
system capabilities.

## Related Issues
Closes GRID-273

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)