### PR TITLE
Update canonical tests to use fuel-moisture map

### DIFF
--- a/src/gridfire/common.clj
+++ b/src/gridfire/common.clj
@@ -82,22 +82,6 @@
         (update-in [:live :herbaceous] (f [:live :herbaceous]))
         (update-in [:live :woody] (f [:live :woody])))))
 
-(defn constant-fuel-moisture
-  "Returns a map of moisture
-  {:dead {:1hr        (0-1)
-          :10hr       (0-1)
-          :100hr      (0-1)}
-   :live {:herbaceous (0-1)
-          :woody      (0-1)}}"
-  [{:keys [fuel-moisture]}]
-  (cond
-    (map? fuel-moisture)
-    fuel-moisture
-
-    (float? fuel-moisture)
-    {:dead (zipmap [:1hr :10hr :100hr]  (repeat fuel-moisture))
-     :live (zipmap [:woody :herbaceous] (repeat fuel-moisture))}))
-
 (defn fuel-moisture-from-raster
   "Returns a map of moisture
   {:dead {:1hr        (0-1)

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -5,7 +5,6 @@
             [gridfire.common               :refer [burnable-fuel-model?
                                                    burnable?
                                                    get-fuel-moisture
-                                                   constant-fuel-moisture
                                                    fuel-moisture-from-raster
                                                    in-bounds?
                                                    burnable-neighbors?
@@ -202,7 +201,6 @@
                                                     (:wind-speed-20ft multiplier-lookup)
                                                     (:wind-speed-20ft perturbations))
         fuel-moisture                 (or (fuel-moisture-from-raster constants here global-clock)
-                                          (constant-fuel-moisture constants)
                                           (get-fuel-moisture relative-humidity temperature))
         [fuel-model spread-info-min]  (rothermel-fast-wrapper fuel-model fuel-moisture)
         midflame-wind-speed           (mph->fpm

--- a/src/gridfire/spec/config.clj
+++ b/src/gridfire/spec/config.clj
@@ -113,9 +113,7 @@
   (s/keys :req-un [::woody ::herbaceous]))
 
 (s/def ::fuel-moisture
-  (s/or
-   :constant ::common/ratio
-   :map      (s/keys :req-un [::dead ::live])))
+  (s/keys :req-un [::dead ::live]))
 
 (s/def ::rh-or-fuel-moisture
   (fn [{:keys [relative-humidity fuel-moisture]}]

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -2,7 +2,6 @@
 (ns gridfire.spotting
   (:require [clojure.core.matrix :as m]
             [gridfire.common :refer [distance-3d
-                                     constant-fuel-moisture
                                      get-fuel-moisture
                                      get-value-at
                                      in-bounds?
@@ -332,7 +331,6 @@
                                           (:wind-from-direction multiplier-lookup)
                                           (:wind-from-direction perturbations))
           fuel-moisture     (or (fuel-moisture-from-raster inputs cell global-clock)
-                                (constant-fuel-moisture inputs)
                                 (get-fuel-moisture rh temperature))
           deltas            (sample-wind-dir-deltas inputs
                                                     fire-line-intensity-matrix

--- a/test/gridfire/canonical_test.clj
+++ b/test/gridfire/canonical_test.clj
@@ -60,6 +60,18 @@
     :raster-20   (->tif :raster-40)
     :raster-40   (->tif :raster-80)))
 
+(defn- ->fuel-moisture-map
+  "Returns a fuel-moisture map given a constant fuel-moisture:
+  {:dead {:1hr        (0-1)
+          :10hr       (0-1)
+          :100hr      (0-1)}
+   :live {:herbaceous (0-1)
+          :woody      (0-1)}}"
+  [fuel-moisture]
+  {:dead (zipmap [:1hr :10hr :100hr]  (repeat fuel-moisture))
+   :live (zipmap [:woody :herbaceous] (repeat fuel-moisture))})
+
+
 (defn- output-directory [{:keys [base-dir
                                  datetime
                                  fuel-model
@@ -151,7 +163,7 @@
                                   :canopy-cover (->tif canopy-cover)
                                   :slope        (->tif slope)
                                   :elevation    (->dem-tif slope)}
-               :fuel-moisture    fuel-moisture
+               :fuel-moisture    (->fuel-moisture-map fuel-moisture)
                :foliar-moisture  foliar-moisture
                :wind-speed-20ft  wind-speed-20ft
                :output-directory (output-directory (assoc params :datetime datetime))}


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Fix the canonical tests to use a map for `:fuel-moisture`, remove `constant-fuel-moisture` fn.

## Related Issues
N/A

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
Run `clj -M:tests -n gridfire.canonical-test`
