### PR TITLE
GRID-276 Make Grass Suppression configurable

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -897,9 +897,10 @@ where these terms have the meanings shown in Table
 For a full description of each of the subcomponents of Rothermel's
 surface fire spread rate equation, see the Rothermel 1972 reference
 above. In addition to applying the base Rothermel equations, GridFire
-reduces the spread rates for all of the Scott & Burgan 40 fuel models
-of the grass subgroup (101-109) by 50%. This addition was originally
-suggested by Chris Lautenberger of REAX Engineering.
+can reduce the spread rates for all of the Scott & Burgan 40 fuel models
+of the grass subgroup (101-109) by 50% by enabling the ~:grass-suppression?~
+configuration. This addition was originally suggested by Chris Lautenberger
+of REAX Engineering.
 
 For efficiency, the surface fire spread equation given above is
 computed first without introducing the effects of wind and slope

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -61,10 +61,10 @@
    [-1 -1] 315.0}) ; NW
 
 (defn rothermel-fast-wrapper
-  [fuel-model-number fuel-moisture]
+  [fuel-model-number fuel-moisture grass-suppression?]
   (let [fuel-model      (-> (build-fuel-model (int fuel-model-number))
                             (moisturize fuel-moisture))
-        spread-info-min (rothermel-surface-fire-spread-no-wind-no-slope fuel-model)]
+        spread-info-min (rothermel-surface-fire-spread-no-wind-no-slope fuel-model grass-suppression?)]
     [fuel-model spread-info-min]))
 
 (defrecord BurnTrajectory
@@ -139,7 +139,7 @@
    :fractional-distance [0-1]}, one for each cell adjacent to here."
   [{:keys [landfire-rasters multiplier-lookup perturbations wind-speed-20ft wind-from-direction
            temperature relative-humidity foliar-moisture ellipse-adjustment-factor
-           cell-size num-rows num-cols] :as constants}
+           cell-size num-rows num-cols grass-suppression?] :as constants}
    fire-spread-matrix
    here
    overflow-trajectory
@@ -202,7 +202,7 @@
                                                     (:wind-speed-20ft perturbations))
         fuel-moisture                 (or (fuel-moisture-from-raster constants here global-clock)
                                           (get-fuel-moisture relative-humidity temperature))
-        [fuel-model spread-info-min]  (rothermel-fast-wrapper fuel-model fuel-moisture)
+        [fuel-model spread-info-min]  (rothermel-fast-wrapper fuel-model fuel-moisture grass-suppression?)
         midflame-wind-speed           (mph->fpm
                                        (* wind-speed-20ft
                                           (wind-adjustment-factor ^long (:delta fuel-model)

--- a/src/gridfire/surface_fire.clj
+++ b/src/gridfire/surface_fire.clj
@@ -24,7 +24,7 @@
    - f_ij [percent of load per size class (%)]
    - f_i [percent of load per category (%)]
    - g_ij [percent of load per size class from Albini_1976_FIREMOD, page 20]"
-  [{:keys [number delta w_o sigma  h rho_p S_T S_e M_x  M_f f_ij f_i g_ij]}]
+  [{:keys [number delta w_o sigma  h rho_p S_T S_e M_x  M_f f_ij f_i g_ij]} & [grass-suppression?]]
   (let [number     (long number)
         delta      (double delta)
         S_e_i      (size-class-sum (fn [i j] (* (-> f_ij i ^double (j)) (-> S_e i ^double (j)))))
@@ -151,7 +151,7 @@
                      0.0)
 
         ;; Addition proposed by Chris Lautenberger (REAX 2015)
-        spread-rate-multiplier (if (grass-fuel-model? number) 0.5 1.0)]
+        spread-rate-multiplier (if (and grass-suppression? (grass-fuel-model? number)) 0.5 1.0)]
 
     {:spread-rate        (* R spread-rate-multiplier)
      :reaction-intensity I_R

--- a/test/gridfire/resources/canonical_test/base-config.edn
+++ b/test/gridfire/resources/canonical_test/base-config.edn
@@ -42,6 +42,7 @@
  :wind-speed-20ft           10  ; (miles/hour)
  :wind-from-direction       90  ; (degrees cw from north)
  :foliar-moisture           0   ; (%)
+ :grass-suppression?        true
 
  ;; Section 4: Number of simulations and (optional) random seed parameter
  :max-runtime               1440 ; 24 hrs   ; (minutes)


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Allows the 50% grass suppression to be toggled on/off via the config key: `:grass-suppression?`

## Related Issues
Closes GRID-276

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
Run `clj -M:test-unit`

## Screenshots

#### Canonical tests w/ grass suppression
![image](https://user-images.githubusercontent.com/1829313/149596084-b6d65339-d8b1-4a61-bc80-6c00f39d92be.png)

#### Canonical tests w/o grass suppression
![burn_history_0](https://user-images.githubusercontent.com/1829313/149596097-5cee3534-7711-4f9c-81a1-31c3e6023578.png)

