### PR TITLE
GRID-294 Add a flame-length-directional-matrix

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3992,7 +3992,7 @@ To control the output of the burn probability layer, which is
 calcualted as the number of times a cell burned divided by the number
 of simulations, include the following mapping:
 
-- *output-*burn-probability*: timestep (in minutes) or keyword `:final`
+- *output-burn-probability*: timestep (in minutes) or keyword `:final`
 
 #+begin_src clojure
 {:output-burn-probability 10}
@@ -4002,27 +4002,27 @@ To specify the output of the flame length sum layer,
 which is the sum of flame lengths across simulations, include
 the following mapping:
 
-- *output-*flame-length-sum*: bolean
+- *output-flame-length-sum*: keyword `:max` or `:directional`
 
 #+begin_src clojure
-{:output-flame-length-sum true}
+{:output-flame-length-sum :max}
 #+end_src
 
 To specify the output of the flame length max layer,
 which is the max of flame lengths across simulations, include
 the following mapping:
 
-- *output-*flame-length-max*: bolean
+- *output-flame-length-max*: keyword `:max` or `:directional`
 
 #+begin_src clojure
-{:output-flame-length-max true}
+{:output-flame-length-max :directional}
 #+end_src
 
 To specify the output of the burn count layer, which is the number of
 times a cell has burned across simulations, include the following
 mapping:
 
-- *output-*burn-count*: bolean
+- *output-burn-count*: boolean
 
 #+begin_src clojure
 {:output-burn-count true}
@@ -4033,7 +4033,7 @@ To specify the output of the spot count layer, which is the number of
 times a spot ignition occured in a cell, include the following
 mapping:
 
-- *output-*spot-count*: bolean
+- *output-spot-count*: boolean
 
 #+begin_src clojure
 {:output-spot-count true}

--- a/src/gridfire/fire_spread_optimal.clj
+++ b/src/gridfire/fire_spread_optimal.clj
@@ -13,6 +13,7 @@
             [gridfire.fuel-models-optimal  :refer [fuel-models-precomputed
                                                    moisturize]]
             [gridfire.spotting-optimal     :as spot-optimal]
+            [gridfire.suppression          :as suppression]
             [gridfire.surface-fire-optimal :refer [rothermel-surface-fire-spread-no-wind-no-slope
                                                    rothermel-surface-fire-spread-max
                                                    compute-spread-rate
@@ -823,40 +824,95 @@
                                                (- burn-period-start ignition-start-time-min-into-day))))
         non-burn-period-clock            (+ burn-period-clock burn-period-dt)
         ignition-start-time              (max ignition-start-time burn-period-clock)
-        band                             (min->hour ignition-start-time)]
+        band                             (min->hour ignition-start-time)
+        suppression                      (:suppression inputs)
+        alpha                            (:suppression-coefficient suppression)
+        suppression-dt                   (some-> suppression :suppression-dt double)]
     (initialize-fire-in-situ-values! inputs matrices band ignited-cells)
-    (loop [global-clock          ignition-start-time
-           band                  band
-           non-burn-period-clock non-burn-period-clock
-           burn-vectors          (ignited-cells->burn-vectors inputs matrices ignited-cells [])
-           spot-ignitions        {}
-           spot-count            0]
+    (loop [global-clock                 ignition-start-time
+           band                         band
+           non-burn-period-clock        non-burn-period-clock
+           suppression-clock            (double (if suppression (+ ignition-start-time suppression-dt) max-runtime))
+           burn-vectors                 (ignited-cells->burn-vectors inputs matrices ignited-cells [])
+           spot-ignitions               {}
+           spot-count                   0
+           total-cells-suppressed       0
+           previous-num-perimeter-cells 0]
       (if (and (< global-clock ignition-stop-time)
                (or (seq burn-vectors) (seq spot-ignitions)))
-        (let [dt-until-max-runtime (- ignition-stop-time global-clock)]
-          (if (= global-clock non-burn-period-clock)
-            (let [timestep  (min non-burn-period-dt dt-until-max-runtime)
+        (let [dt-until-max-runtime               (- ignition-stop-time global-clock)
+              ^double dt-until-suppression-clock (when suppression-dt (- suppression-clock global-clock))]
+          (cond
+            (and suppression (= global-clock suppression-clock))
+            (let [max-runtime-fraction           (/ global-clock max-runtime)
+                  [bvs-to-process-next
+                   total-cells-suppressed
+                   previous-num-perimeter-cells] (suppression/suppress-burn-vectors max-runtime-fraction
+                                                                                    alpha
+                                                                                    previous-num-perimeter-cells
+                                                                                    total-cells-suppressed
+                                                                                    burn-vectors)]
+              (recur global-clock
+                     band
+                     non-burn-period-clock
+                     (+ global-clock suppression-dt)
+                     bvs-to-process-next
+                     spot-ignitions
+                     spot-count
+                     total-cells-suppressed
+                     previous-num-perimeter-cells))
+
+            (= global-clock non-burn-period-clock)
+            (let [timestep  (double (min non-burn-period-dt dt-until-max-runtime))
                   new-clock (+ global-clock timestep)
                   new-band  (min->hour new-clock)]
-              (recur new-clock
-                     new-band
-                     (+ new-clock burn-period-dt)
-                     burn-vectors
-                     (if (zero? non-burn-period-dt)
-                       spot-ignitions
-                       {})
-                     spot-count))
+              (if (and suppression (<= suppression-clock new-clock))
+                (let [suppression-clocks             (iterate #(+ (double %) suppression-dt) suppression-clock)
+                      last-suppression-clock         (double (last (take-while #(<= (double %) new-clock) suppression-clocks)))
+                      [bvs-to-process-next
+                       total-cells-suppressed
+                       previous-num-perimeter-cells] (suppression/suppress-burn-vectors (/ last-suppression-clock max-runtime)
+                                                                                        alpha
+                                                                                        previous-num-perimeter-cells
+                                                                                        total-cells-suppressed
+                                                                                        burn-vectors)]
+                  (recur new-clock
+                         new-band
+                         (+ new-clock burn-period-dt)
+                         (+ last-suppression-clock suppression-dt)
+                         bvs-to-process-next
+                         (if (zero? non-burn-period-dt)
+                           spot-ignitions
+                           {})
+                         spot-count
+                         total-cells-suppressed
+                         previous-num-perimeter-cells))
+                (recur new-clock
+                       new-band
+                       (+ new-clock burn-period-dt)
+                       suppression-clock
+                       burn-vectors
+                       (if (zero? non-burn-period-dt)
+                         spot-ignitions
+                         {})
+                       spot-count
+                       total-cells-suppressed
+                       previous-num-perimeter-cells)))
+
+            :else
             (let [dt-until-new-hour              (- 60.0 (rem global-clock 60.0))
-                  dt-until-non-burn-period-clock (-  non-burn-period-clock global-clock)
+                  dt-until-non-burn-period-clock (- non-burn-period-clock global-clock)
                   bvs                            (if (and (> global-clock ignition-start-time)
                                                           (or (= dt-until-new-hour 60.0)
                                                               (= dt-until-non-burn-period-clock burn-period-dt)))
                                                    (recompute-burn-vectors inputs matrices band burn-vectors)
                                                    burn-vectors)
-                  timestep                       (-> (compute-dt cell-size bvs)
-                                                     (min dt-until-new-hour)
-                                                     (min dt-until-max-runtime)
-                                                     (min dt-until-non-burn-period-clock))
+                  timestep                       (double
+                                                  (cond-> (compute-dt cell-size bvs)
+                                                    dt-until-new-hour              (min dt-until-new-hour)
+                                                    dt-until-max-runtime           (min dt-until-max-runtime)
+                                                    dt-until-non-burn-period-clock (min dt-until-non-burn-period-clock)
+                                                    dt-until-suppression-clock     (min dt-until-suppression-clock)))
                   new-clock                      (+ global-clock timestep)
                   [grown-bvs
                    ignited-cells]                (grow-burn-vectors! matrices global-clock timestep bvs)
@@ -867,7 +923,7 @@
                                                       (transition-burn-vectors inputs matrices band global-clock new-clock 0.99))
                   promoted-transitioned-bvs      (->> transitioned-bvs
                                                       (ignited-cells->burn-vectors inputs matrices transition-ignited-cells)
-                                                      (promote-burn-vectors inputs matrices global-clock new-clock 0.99))
+                                                      (promote-burn-vectors inputs matrices global-clock new-clock 0.99)) ;TODO optimize, promoting twice
                   [spot-bvs
                    spot-ignite-now-count
                    spot-ignite-later
@@ -878,7 +934,7 @@
                                                                              band
                                                                              new-clock)
                   promoted-spot-bvs              (->> (into promoted-transitioned-bvs spot-bvs)
-                                                      (promote-burn-vectors inputs matrices global-clock new-clock 1.49))
+                                                      (promote-burn-vectors inputs matrices global-clock new-clock 1.49)) ;TODO optimize, promoting thrice
                   [transition-promoted-spot-bvs
                    _]                            (transition-burn-vectors inputs matrices band global-clock new-clock 0.49 promoted-spot-bvs)]
               ;; TODO if spot ignitions is updated to have varying burn probability make sure there are no duplicates
@@ -889,9 +945,12 @@
               (recur new-clock
                      (min->hour new-clock)
                      non-burn-period-clock
+                     suppression-clock
                      transition-promoted-spot-bvs
                      spot-ignite-later
-                     (+ spot-count ^long spot-ignite-now-count)))))
+                     (+ spot-count ^long spot-ignite-now-count)
+                     total-cells-suppressed
+                     previous-num-perimeter-cells))))
         (let [fire-type-matrix (:fire-type-matrix matrices)]
           {:exit-condition                  (if (>= global-clock ignition-stop-time) :max-runtime-reached :no-burnable-fuels)
            :global-clock                    global-clock
@@ -987,6 +1046,9 @@
   |                                    |                    | :num-firebrands -> long                                   |
   |                                    |                    | :surface-fire-spotting -> map                             |
   |                                    |                    | :crown-fire-spotting-percent -> double or [double double] |
+  |------------------------------------+--------------------+-----------------------------------------------------------|
+  | :suppression                       | map                | :suppression-dt -> double                                 |
+  |                                    |                    | :suppression-coefficient -> double                        |
   |------------------------------------+--------------------+-----------------------------------------------------------|"
   (fn [inputs]
     (if (vector? (:initial-ignition-site inputs))

--- a/src/gridfire/inputs.clj
+++ b/src/gridfire/inputs.clj
@@ -269,13 +269,13 @@
 
 (defn add-aggregate-matrices
   [{:keys
-    [max-runtime-samples num-rows num-cols output-burn-count? output-burn-probability output-flame-length-sum?
-     output-flame-length-max? output-spot-count?] :as inputs}]
+    [max-runtime-samples num-rows num-cols output-burn-count? output-burn-probability
+     output-flame-length-sum output-flame-length-max output-spot-count?] :as inputs}]
   (assoc inputs
          :burn-count-matrix       (when (or output-burn-count? output-burn-probability)
                                     (initialize-burn-count-matrix output-burn-probability max-runtime-samples num-rows num-cols))
-         :flame-length-sum-matrix (when output-flame-length-sum? (t/new-tensor [num-rows num-cols]))
-         :flame-length-max-matrix (when output-flame-length-max? (t/new-tensor [num-rows num-cols]))
+         :flame-length-sum-matrix (when output-flame-length-sum (t/new-tensor [num-rows num-cols]))
+         :flame-length-max-matrix (when output-flame-length-max (t/new-tensor [num-rows num-cols]))
          :spot-count-matrix       (when output-spot-count? (t/new-tensor [num-rows num-cols]))))
 
 (defn add-burn-period-params

--- a/src/gridfire/outputs.clj
+++ b/src/gridfire/outputs.clj
@@ -76,13 +76,13 @@
             (output-png outputs probability-matrix output-name envelope)))))))
 
 (defn write-flame-length-sum-layer!
-  [{:keys [envelope output-flame-length-sum? flame-length-sum-matrix] :as outputs}]
-  (when output-flame-length-sum?
+  [{:keys [envelope output-flame-length-sum flame-length-sum-matrix] :as outputs}]
+  (when output-flame-length-sum
     (output-geotiff outputs flame-length-sum-matrix "flame_length_sum" envelope)))
 
 (defn write-flame-length-max-layer!
-  [{:keys [envelope output-flame-length-max? flame-length-max-matrix] :as outputs}]
-  (when output-flame-length-max?
+  [{:keys [envelope output-flame-length-max flame-length-max-matrix] :as outputs}]
+  (when output-flame-length-max
     (output-geotiff outputs flame-length-max-matrix "flame_length_max" envelope)))
 
 (defn write-burn-count-layer!

--- a/src/gridfire/spec/config.clj
+++ b/src/gridfire/spec/config.clj
@@ -160,6 +160,16 @@
                    ::crown-fire-spotting-percent]
           :opt-un [::surface-fire-spotting]))
 
+;; Suppression
+
+(s/def ::suppression-dt number?)
+
+(s/def ::suppression-coefficient number?)
+
+(s/def ::suppression
+  (s/keys :req-un [::suppression-dt
+                   ::suppression-coefficient]))
+
 ;; Perturbations
 
 (s/def ::perturbations
@@ -212,8 +222,8 @@
 (s/def ::output-burn-probability  ::output-frequency) ; FIXME: Why isn't this also just boolean?
 (s/def ::output-burn-count?       boolean?)
 (s/def ::output-spot-count?       boolean?)
-(s/def ::output-flame-length-max? boolean?)
-(s/def ::output-flame-length-sum? boolean?)
+(s/def ::output-flame-length-max  #{:max :directional})
+(s/def ::output-flame-length-sum  #{:max :directional})
 
 ;;=============================================================================
 ;; Config Map
@@ -245,6 +255,7 @@
              ::relative-humidity
              ::fuel-moisture
              ::spotting
+             ::suppression
              ::perturbations
              ::output-directory
              ::outfile-suffix
@@ -257,8 +268,8 @@
              ::output-burn-probability
              ::output-burn-count?
              ::output-spot-count?
-             ::output-flame-length-max?
-             ::output-flame-length-sum?])
+             ::output-flame-length-max
+             ::output-flame-length-sum])
    ::ignition-layer-or-ignition-csv
    ::max-runtime-or-ignition-csv
    ::simulations-or-ignition-csv

--- a/src/gridfire/suppression.clj
+++ b/src/gridfire/suppression.clj
@@ -1,0 +1,258 @@
+(ns gridfire.suppression
+  "An algorithm emulating human interventions reacting to fire spread
+  by suppressing ('putting out') chosen contiguous segments of the
+  fire front, typically backing and flanking fires."
+  (:require [gridfire.conversion :refer [rad->deg]]))
+
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn- combine-average ^double
+  [^double avg-old ^long count-old ^double avg-new ^long count-new]
+  (if (zero? (+ count-old count-new))
+    0.0
+    (/ (+ (* avg-old count-old)
+          (* avg-new count-new))
+       (+ count-old count-new))))
+
+(defn- remove-average ^double
+  [^double avg-old ^long count-old ^double avg-to-remove ^long count-of-avg-to-remove]
+  (if (zero? (- count-old count-of-avg-to-remove))
+    0.0
+    (/ (- (* avg-old count-old) (* avg-to-remove count-of-avg-to-remove))
+       (- count-old count-of-avg-to-remove))))
+
+(defn- compute-contiguous-slices
+  "Given number of cells to suppress and a map of average directional spread
+  rate data with the form: angular-slice -> [average-dsr cell-count] return a
+  sorted map where each map entry:
+
+  [[`list-of-slices` `avg-dsr`] `cell-count`]
+
+  represents a contiguous segment of the fire front, which we locate
+  by `list-of-slices`, the list of successive degree slices covering
+  it; `cell-count` represents the number of active perimeter cells in
+  that segment, with `cell-count` no smaller than
+  `num-cells-to-suppress`, but possibly bigger.
+
+  NOTE: This constraint may be violated if a segment is adjacent to an
+  already suppressed slice, in which case the segment will be included
+  in the returned map even if its `cell-count` is smaller than
+  `num-cells-to-suppress`.
+
+  Note that the returned segments will tend to overlap - think of a
+  sliding window of (up to `num-cells-to-suppress`) contiguous active
+  cells, rotating around the centroid: the segments returned by this
+  function are regular snapshots of this window."
+  [^long num-cells-to-suppress angular-slice->avg-dsr+num-cells]
+  (loop [sorted-contiguous-slices (sorted-map-by (fn [[_ x1] [_ x2]]
+                                                   (compare x1 x2)))
+         slice-data               (into [] (seq angular-slice->avg-dsr+num-cells))
+         cur-contiguous-slices    []
+         cur-dsr                  0
+         cur-count                0
+         left-idx                 -1
+         right-idx                0]
+    (cond
+
+      (= left-idx 0)
+      sorted-contiguous-slices
+
+      ;; Do not include already suppressed regions in the longest
+      ;; contiguous slice calculation.
+      (let [[_ [_ cell-count]] (nth slice-data right-idx)
+            cell-count         (long cell-count)]
+        (and (< cur-count num-cells-to-suppress) (zero? cell-count)))
+      (let [next-right-idx (if (= right-idx (dec (count slice-data)))
+                             0
+                             (+ right-idx 1))]
+        (recur (if (seq cur-contiguous-slices)
+                 (assoc sorted-contiguous-slices [cur-contiguous-slices cur-dsr] cur-count)
+                 sorted-contiguous-slices)
+               slice-data
+               []
+               0
+               0
+               (if (< right-idx left-idx) 0 next-right-idx)
+               next-right-idx))
+
+      (< cur-count num-cells-to-suppress)
+      ;; expand right
+      (let [[slice [avg-dsr cell-count]] (nth slice-data right-idx)
+            cell-count                   (long cell-count)]
+        (recur sorted-contiguous-slices
+               slice-data
+               (conj cur-contiguous-slices slice)
+               (combine-average cur-dsr cur-count avg-dsr cell-count)
+               (+ cur-count cell-count)
+               left-idx
+               (if (= right-idx (dec (count slice-data)))
+                 0
+                 (+ right-idx 1))))
+
+      :else
+      ;; shrink left
+      (let [[_ [avg-dsr cell-count]] (nth slice-data (if (= -1 left-idx) 0 left-idx))
+            cell-count               (long cell-count)]
+        (recur (assoc sorted-contiguous-slices [cur-contiguous-slices cur-dsr] cur-count)
+               slice-data
+               (subvec cur-contiguous-slices 1)
+               (remove-average cur-dsr cur-count avg-dsr cell-count)
+               (- cur-count cell-count)
+               (long
+                (cond
+                  (= left-idx (dec (count slice-data))) 0
+                  (= -1 left-idx)                       1
+                  :else                                 (+ left-idx 1)))
+               right-idx)))))
+
+(defn- compute-sub-segment
+  [angular-slice->avg-dsr+num-cells slices cells-needed]
+  (let [slices                           (set slices)
+        angular-slice->avg-dsr+num-cells (reduce (fn [acc [slice avg-dsr+num-cells]]
+                                                   (if (contains? slices slice)
+                                                     (assoc acc slice avg-dsr+num-cells)
+                                                     (assoc acc slice [0.0 0.0]))) ;; Needed because the segment should not be treated as circular list
+                                                 (sorted-map)
+                                                 angular-slice->avg-dsr+num-cells) ;; FIXME: This seems inefficient
+        contiguous-slices                (compute-contiguous-slices cells-needed angular-slice->avg-dsr+num-cells)
+        [[slices _] cell-count]          (first contiguous-slices)]
+    [slices cell-count]))
+
+;; FIXME: This algorithm sums the cell counts of each segment, but it
+;; never checks to see if the segments overlap, which suggests that we
+;; will often undersuppress vs `num-cells-to-suppress`.
+(defn- compute-slices-to-suppress
+  "Returns a tuple of `slices-to-suppress` and `suppressed-count`.
+  This algorithm will convert `angular-slice->avg-dsr+num-cells` to a sorted map of
+  `angular-slices+avg-dsr->num-cells`. Using this map the algorithm will collect
+  the sequence of angular-slices until we have a cell-count of at least
+  `num-cells-to-suppress`."
+  [^long num-cells-to-suppress angular-slice->avg-dsr+num-cells]
+  (let [angular-slices+avg-dsr->num-cells (compute-contiguous-slices num-cells-to-suppress angular-slice->avg-dsr+num-cells)
+        [[slices _] cell-count]           (first angular-slices+avg-dsr->num-cells)
+        cell-count                        (long cell-count)]
+    (if (>= cell-count num-cells-to-suppress)
+      [slices cell-count]
+      ;; The optimal segment does not contain enough cells, so we add more segments:
+      (loop [[segment & rest-to-process] (rest angular-slices+avg-dsr->num-cells)
+             cells-needed                (- num-cells-to-suppress cell-count)
+             slices-to-suppress          slices]
+        (if (and segment (pos? cells-needed))
+          (let [[[slices _] cell-count] segment
+                cell-count              (long cell-count)]
+            (if (<= cell-count cells-needed)
+              (recur rest-to-process (- cells-needed cell-count) (into slices-to-suppress slices))
+              ;; this segment has more than we need, compute subsegment:
+              (let [[sub-segment-slices sub-segment-count] (compute-sub-segment angular-slice->avg-dsr+num-cells slices cells-needed)
+                    sub-segment-count                      (long sub-segment-count)]
+                (recur rest-to-process (- cells-needed sub-segment-count) (into slices-to-suppress sub-segment-slices)))))
+          [slices-to-suppress (- num-cells-to-suppress cells-needed)])))))
+
+(defn- average
+  [coll]
+  (/ (double (reduce + coll)) (long (count coll))))
+
+(defn- compute-avg-dsr
+  [burn-vectors]
+  (-> (reduce (fn ^double [^double acc burn-vector]
+                (+ acc (double (:spread-rate burn-vector))))
+              0.0
+              burn-vectors)
+      double
+      (/ (count burn-vectors))))
+
+(defn- compute-cell-count
+  [burn-vectors]
+  (count
+   (into #{}
+         (map (juxt :i :j))
+         burn-vectors)))
+
+(defn- compute-avg-dsr-data
+  "Returns a sorted map where each map entry:
+
+  [`angular-slice` [`directional-spread-rate` `cell-count`]]
+
+  represents a collection of stats computed for an `angular-slice`. The
+  `directional-spread-rate` is the average value among the active
+  perimeter cells that fall within that slice. The `cell-count` is the
+  count of those perimeter cells."
+  [^double angular-slice-size slice->BurnVectors]
+  (reduce (fn [acc slice]
+            (let [burn-vectors (get slice->BurnVectors slice)]
+              (if (seq burn-vectors)
+                (assoc acc slice [(compute-avg-dsr burn-vectors) (compute-cell-count burn-vectors)])
+                (assoc acc slice [0.0 0.0]))))
+          (sorted-map)
+          (range 0.0 (/ 360.0 angular-slice-size))))
+
+(defn- angle-cw-from-east ^double
+  [^long i1 ^long j1 ^long i0 ^long j0]
+  (let [di    (- i1 i0)
+        dj    (- j1 j0)
+        theta (rad->deg (Math/atan2 di dj))]
+    (if (neg? di)
+      (+ theta 360.0)
+      theta)))
+
+(defn- nearest-angular-slice ^double
+  [^double theta ^double angular-slice-size]
+  (Math/floor (/ theta angular-slice-size)))
+
+(defn- group-burn-vectors
+  "Returns a map where each entry:
+
+  [`angular-slice` [BurnVector BurnVector ...]]
+
+  represents a collection of BurnVectors that fall within an `angular-slice`.
+  The `angular-slice` is defined as the degree clockwise from EAST of the
+  `centroid` cell. angular-slice 0 = East = 0.0 degrees."
+  [centroid ^double angular-slice-size burn-vectors]
+  (let [[i0 j0] centroid]
+    (group-by (fn [burn-vector] (-> (angle-cw-from-east (:i burn-vector) (:j burn-vector) i0 j0)
+                                    (nearest-angular-slice angular-slice-size)))
+              burn-vectors)))
+
+(defn- compute-centroid-cell
+  "Returns [i j] that is the centroid of a given list of [i j] cells"
+  [cells]
+  (let [row (average (mapv #(nth % 0) cells))
+        col (average (mapv #(nth % 1) cells))]
+    [(long row) (long col)]))
+
+(defn- compute-fraction-contained ^double
+  [^double max-runtime-fraction ^double suppression-coefficient]
+  (Math/pow (/ (* 2.0 max-runtime-fraction)
+               (+ 1.0 (Math/pow max-runtime-fraction 2.0)))
+            suppression-coefficient))
+
+(defn suppress-burn-vectors
+  [max-runtime-fraction suppression-coefficient previous-num-perimeter-cells previous-suppressed-count burn-vectors]
+  (let [max-runtime-fraction         (double max-runtime-fraction)
+        suppression-coefficient      (double suppression-coefficient)
+        previous-num-perimeter-cells (long previous-num-perimeter-cells)
+        previous-suppressed-count    (long previous-suppressed-count)
+        active-perimeter-cells       (into #{}
+                                           (map (juxt :i :j))
+                                           burn-vectors)
+        fraction-contained           (compute-fraction-contained max-runtime-fraction suppression-coefficient)
+        num-tracked-perimeter-cells  (+ (long (count active-perimeter-cells)) previous-suppressed-count)
+        num-fizzled-perimeter-cells  (max 0 (- previous-num-perimeter-cells num-tracked-perimeter-cells))
+        num-perimeter-cells          (max previous-num-perimeter-cells num-tracked-perimeter-cells)
+        current-suppressed-count     (+ previous-suppressed-count num-fizzled-perimeter-cells)
+        next-suppressed-count        (long (* fraction-contained num-perimeter-cells))
+        num-cells-to-suppress        (- next-suppressed-count current-suppressed-count)]
+    (if (> num-cells-to-suppress 0)
+      (let [centroid-cell          (compute-centroid-cell active-perimeter-cells)
+            angular-slice-size     5.0
+            slice->BurnVectors     (group-burn-vectors centroid-cell angular-slice-size burn-vectors)
+            [slices-to-suppress
+             suppressed-count]     (->> (compute-avg-dsr-data angular-slice-size slice->BurnVectors)
+                                        (compute-slices-to-suppress num-cells-to-suppress))
+            slices-to-suppress-set (set slices-to-suppress)
+            slices-to-keep         (remove #(contains? slices-to-suppress-set %) (keys slice->BurnVectors))
+            burn-vectors-to-keep   (into []
+                                         (mapcat #(get slice->BurnVectors %))
+                                         slices-to-keep)]
+        [burn-vectors-to-keep (+ current-suppressed-count ^long suppressed-count) num-perimeter-cells])
+      [burn-vectors current-suppressed-count num-perimeter-cells])))

--- a/test/gridfire/canonical_test.clj
+++ b/test/gridfire/canonical_test.clj
@@ -18,9 +18,9 @@
 (def ^:private surface-scenarios  {:fuel-model         [:grass-fbfm40 :timber-litter-fbfm40 :grass-extreme-fbfm40 :shrub-fbfm40 :blowdown-fbfm40]
                                    :canopy-cover       [:zero-raster]
                                    :slope              [:zero-raster :slp-10 :slp-20 :slp-30]
-                                   :wind-speed-20ft    [0 10 20 40]
+                                   :wind-speed-20ft    [0.0 10.0 20.0 40.0]
                                    :fuel-moisture      (range 0.0 0.25 0.05)
-                                   :foliar-moisture    [0 0.5 1.0]
+                                   :foliar-moisture    [0.0 0.5 1.0]
                                    :canopy-base-height [:zero-raster]
                                    :crown-bulk-density [:zero-raster]})
 
@@ -36,20 +36,29 @@
 (def ^:private surface-spotting-scenarios {:fuel-model         [:firebreak]
                                            :canopy-cover       [:zero-raster]
                                            :slope              [:zero-raster]
-                                           :wind-speed-20ft    [5 10 15 20]
+                                           :wind-speed-20ft    [5.0 10.0 15.0 20.0]
                                            :fuel-moisture      [0.0]
-                                           :foliar-moisture    [0]
+                                           :foliar-moisture    [0.0]
                                            :canopy-base-height [:zero-raster]
                                            :crown-bulk-density [:zero-raster]})
 
 (def ^:private crown-spotting-scenarios {:fuel-model         [:firebreak]
                                          :canopy-cover       [:raster-100]
                                          :slope              [:zero-raster]
-                                         :wind-speed-20ft    [5 10 15 20]
+                                         :wind-speed-20ft    [5.0 10.0 15.0 20.0]
                                          :fuel-moisture      [0.0]
-                                         :foliar-moisture    [0]
+                                         :foliar-moisture    [0.0]
                                          :canopy-base-height [:raster-2]
                                          :crown-bulk-density [:raster-100]})
+
+(def ^:private suppression-scenarios {:fuel-model         [:blowdown-fbfm40]
+                                      :canopy-cover       [:zero-raster]
+                                      :slope              [:slp-10]
+                                      :wind-speed-20ft    [0.0]
+                                      :fuel-moisture      [0.0]
+                                      :foliar-moisture    [0.0]
+                                      :canopy-base-height [:zero-raster]
+                                      :crown-bulk-density [:zero-raster]})
 
 ;;; Helpers
 
@@ -71,7 +80,7 @@
 
 (defn- ->tif [filekey]
   {:source (str canonical-dir (name filekey) ".tif")
-   :type :geotiff})
+   :type   :geotiff})
 
 (defn- ->dem-tif [slope]
   (case slope
@@ -183,15 +192,16 @@
          (csv/write-csv out))))
 
 (defn- gen-scenario
-  [{:keys [datetime
-           fuel-model
-           canopy-cover
-           slope
-           fuel-moisture
-           foliar-moisture
-           wind-speed-20ft
-           canopy-base-height
-           crown-bulk-density] :as params}]
+  [{:keys
+    [datetime
+     fuel-model
+     canopy-cover
+     slope
+     fuel-moisture
+     foliar-moisture
+     wind-speed-20ft
+     canopy-base-height
+     crown-bulk-density] :as params}]
   (deep-merge base-config
               {:params           params
                :landfire-layers  {:fuel-model   (->tif fuel-model)
@@ -209,25 +219,25 @@
 
 (defn- gen-scenarios [scenario-type scenarios]
   (deep-flatten
-    (let [datetime (now)]
-      (for [fuel-model         (:fuel-model scenarios)
-            canopy-cover       (:canopy-cover scenarios)
-            slope              (:slope scenarios)
-            fuel-moisture      (:fuel-moisture scenarios)
-            foliar-moisture    (:foliar-moisture scenarios)
-            wind-speed-20ft    (:wind-speed-20ft scenarios)
-            canopy-base-height (:canopy-base-height scenarios)
-            crown-bulk-density (:crown-bulk-density scenarios)]
-        (gen-scenario {:scenario-type      scenario-type
-                       :fuel-model         fuel-model
-                       :canopy-base-height canopy-base-height
-                       :canopy-cover       canopy-cover
-                       :crown-bulk-density crown-bulk-density
-                       :datetime           datetime
-                       :fuel-moisture      fuel-moisture
-                       :foliar-moisture    foliar-moisture
-                       :slope              slope
-                       :wind-speed-20ft    wind-speed-20ft})))))
+   (let [datetime (now)]
+     (for [fuel-model         (:fuel-model scenarios)
+           canopy-cover       (:canopy-cover scenarios)
+           slope              (:slope scenarios)
+           fuel-moisture      (:fuel-moisture scenarios)
+           foliar-moisture    (:foliar-moisture scenarios)
+           wind-speed-20ft    (:wind-speed-20ft scenarios)
+           canopy-base-height (:canopy-base-height scenarios)
+           crown-bulk-density (:crown-bulk-density scenarios)]
+       (gen-scenario {:scenario-type      scenario-type
+                      :fuel-model         fuel-model
+                      :canopy-base-height canopy-base-height
+                      :canopy-cover       canopy-cover
+                      :crown-bulk-density crown-bulk-density
+                      :datetime           datetime
+                      :fuel-moisture      fuel-moisture
+                      :foliar-moisture    foliar-moisture
+                      :slope              slope
+                      :wind-speed-20ft    wind-speed-20ft})))))
 
 ;;; Tests
 
@@ -256,8 +266,15 @@
     (results->csv test-file (map run-sim! (gen-scenarios :crown-spotting crown-spotting-scenarios)))))
 
 #_(deftest ^:crown-spotting test-crown-spotting-scenarios
-  (let [test-file (str "test-crown-spotting-"(now)".csv")]
-    (run-sim! (first (gen-scenarios :spotting crown-spotting-scenarios)))))
+    (let [test-file (str "test-crown-spotting-"(now)".csv")]
+      (run-sim! (first (gen-scenarios :spotting crown-spotting-scenarios)))))
+
+(deftest ^:suppression test-suppression-scenario
+  (run-sim! (-> (first (gen-scenarios :suppression suppression-scenarios))
+                (assoc :output-layers {:directional-flame-length 72
+                                       :flame-length             :final})
+                (assoc :suppression {:suppression-dt          300
+                                     :suppression-coefficient 2.0}))))
 
 (comment
   (run-tests 'gridfire.canonical-test)

--- a/test/gridfire/suppression_test.clj
+++ b/test/gridfire/suppression_test.clj
@@ -1,0 +1,74 @@
+(ns gridfire.suppression-test
+  (:require
+   [clojure.test :refer [are deftest testing is]]
+   [gridfire.suppression :as su]))
+
+
+(deftest ^:unit angle-cw-from-east-test
+  (are [i j expected] (= (#'gridfire.suppression/angle-cw-from-east i j 10 10) expected)
+    10 11 0.0     ;E
+    11 11 45.0    ;SE
+    11 10 90.0    ;S
+    11 9  135.0   ;SW
+    10 9  180.0   ;W
+    9  9  225.0   ;NW
+    9  10 270.0   ;N
+    9  11 315.0)) ;NE
+
+(deftest ^:unit nearest-floor-test
+  (let [slice-size 5]
+    (are [degree expected-bin] (= (#'gridfire.suppression/nearest-angular-slice degree slice-size) expected-bin)
+      0.0  0.0
+      2.5  0.0
+      5.0  1.0
+      7.5  1.0
+      10.0 2.0
+      12.5 2.0
+      15.0 3.0)))
+
+(deftest ^:unit combine-remove-average-test
+  (let [[avg-old count-old] [100.0 10]
+        [avg-new count-new] [75.0  5]]
+    (is (= avg-old
+           (-> (#'gridfire.suppression/combine-average avg-old count-old avg-new count-new)
+               (#'gridfire.suppression/remove-average (+ count-old count-new) avg-new count-new)))
+        "should get the original average if adding and then removing the same average.")))
+
+(deftest ^:unit compute-contiguous-slices-test
+  (testing "simple case"
+    (let [num-cells-to-suppress 100
+          avg-dsr-data          {0.0 [2.0 25]
+                                 1.0 [2.0 25]
+                                 2.0 [2.0 25]
+                                 3.0 [2.0 25]}]
+
+      (is (= {['(2.0 1.0 0.0 3.0) 2.0] 100}
+             (#'gridfire.suppression/compute-contiguous-slices num-cells-to-suppress avg-dsr-data)))))
+
+  (testing "segments sorted by average spread-rate"
+    (let [num-cells-to-suppress 6
+          avg-dsr-data          {0.0 [6.0 2]
+                                 1.0 [5.0 2]
+                                 2.0 [4.0 2]
+                                 3.0 [3.0 2]
+                                 4.0 [2.0 2]
+                                 5.0 [1.0 2]}]
+      (is (= {['(5.0 4.0 3.0) 2.0] 6
+              ['(0.0 5.0 4.0) 3.0] 6
+              ['(1.0 0.0 5.0) 4.0] 6
+              ['(2.0 1.0 0.0) 5.0] 6}
+             (#'gridfire.suppression/compute-contiguous-slices num-cells-to-suppress avg-dsr-data)))))
+
+  (testing "lowest averge spread rate segments span over bin 0.0"
+    (let [num-cells-to-suppress 6
+          avg-dsr-data          {0.0 [2.0 2]
+                                 1.0 [1.0 2]
+                                 2.0 [6.0 2]
+                                 3.0 [5.0 2]
+                                 4.0 [4.0 2]
+                                 5.0 [3.0 2]}]
+      (is (= {['(1.0 0.0 5.0) 2.0] 6
+              ['(0.0 5.0 4.0) 3.0] 6
+              ['(5.0 4.0 3.0) 4.0] 6
+              ['(4.0 3.0 2.0) 5.0] 6}
+             (#'gridfire.suppression/compute-contiguous-slices num-cells-to-suppress avg-dsr-data))))))


### PR DESCRIPTION
## Purpose
Add flame-length-directional-matrix which stores the flame-length value associated with the direction normal to the fire front.

Additional changes:
- fix bug: pass accumulated burn vectors to promote phase. This is needed to make sure all burn vectors in the cell gets promoted
- refactor: `transition-burn-vectors` and `run-loop` can be simplified
- fix bug: spot burn vectors should stamp 1.0 in fire-spread-matrix
- allow fizzle out burn-vectors to be created, they will get pruned out during promotion phase

## Related Issues
Closes GRID-294

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)