### PR TITLE
GRID-331 Fix elm_to_grid parsing

### DIFF
--- a/resources/elm_to_grid.clj
+++ b/resources/elm_to_grid.clj
@@ -409,14 +409,14 @@
 (def regex-for-array-item #"^[A-Z0-9\_]+\(\d+\)")
 
 (defn convert-key [s]
-  (when (seq s)
+  (when (string? s)
     (let [s-trimmed (str/trim s)]
      (if (re-matches regex-for-array-item s-trimmed)
        (str/join "-" (str/split s-trimmed #"[\(\)]"))
        s-trimmed))))
 
 (defn convert-val [s]
-  (when (seq s)
+  (when (string? s)
     (let [s-trimmed  (str/trim s)
           char-count (count s-trimmed)]
       (cond


### PR DESCRIPTION
## Purpose
Some values (not needed by GF) had empty values. The elm_to_grid.clj failed for some active fire runs because it tried to apply string manipulation on nil. The fix would be to check for empty strings before applying any string manipulation

## Related Issues
Closes GRID-331

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)