### PR TITLE
GRID-348 use dead resposne host to geosync requests

### DIFF
--- a/src/gridfire/server.clj
+++ b/src/gridfire/server.clj
@@ -34,22 +34,22 @@
 (def date-from-format "yyyy-MM-dd HH:mm zzz")
 (def date-to-format   "yyyyMMdd_HHmmss")
 
-(defn- build-geosync-request [{:keys [fire-name ignition-time] :as _request} {:keys [host port] :as _config}]
+(defn- build-geosync-request [{:keys [fire-name ignition-time] :as _request}]
   (let [timestamp (convert-date-string ignition-time date-from-format date-to-format)]
     (json/write-str
      {"action"             "add"
       "dataDir"            (format "/var/www/html/fire_spread_forecast/%s/%s" fire-name timestamp)
       "geoserverWorkspace" (format "fire-spread-forecast_%s_%s" fire-name timestamp)
-      "responseHost"       host
-      "responsePort"       port})))
+      "responseHost"       "some.dead.org"
+      "responsePort"       12345})))
 
 ;; FIXME: Pass the geosync-server-config values in through gridfire.cli rather than hardcoding them.
-(defn- send-geosync-request! [request config]
+(defn- send-geosync-request! [request]
   (let [geosync-server-config {:response-host "data.pyregence.org" :response-port 31337}]
     (when (spec/valid? ::server-spec/gridfire-server-response-minimal geosync-server-config)
       (sockets/send-to-server! (:response-host geosync-server-config)
                                (:response-port geosync-server-config)
-                               (build-geosync-request request config)))))
+                               (build-geosync-request request)))))
 
 (defn- build-gridfire-response [request {:keys [host port] :as _config} status status-msg]
   (json/write-str (merge request
@@ -214,7 +214,7 @@
       (let [[status status-msg] (process-request! request config)]
         (log-str "-> " status-msg)
         (if (= (:type request) :active-fire)
-          (send-geosync-request! request config)
+          (send-geosync-request! request)
           (send-gridfire-response! request config status status-msg)))
       (when @*server-running?
         (recur @(first (alts!! [=job-queue= =stand-by-queue=] :priority true)))))))


### PR DESCRIPTION
-------

## Purpose
Use dead response host and port in geosync requests to avoid infinite
ping pong when invalid requests are sent to GeoSync.

## Related Issues
Closes GRID-348

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)