### PR TITLE
Parallelized outputs-writing code using Manifold. #review GRID-353

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -16,7 +16,8 @@
         org.postgresql/postgresql           {:mvn/version "42.2.23"}
         sig-gis/magellan                    {:mvn/version "20210401"}
         sig-gis/triangulum                  {:git/url "https://github.com/sig-gis/triangulum"
-                                             :sha     "5b179a97ebd8fbcbff51776db06d9770cb649b9d"}}
+                                             :sha     "5b179a97ebd8fbcbff51776db06d9770cb649b9d"}
+        manifold/manifold                   {:mvn/version "0.2.4"}}
 
  :mvn/repos {"osgeo" {:url "https://repo.osgeo.org/repository/release/"}}
 

--- a/src/gridfire/core.clj
+++ b/src/gridfire/core.clj
@@ -8,6 +8,7 @@
             [gridfire.outputs      :as outputs]
             [gridfire.simulations  :as simulations]
             [gridfire.spec.config  :as config-spec]
+            [manifold.deferred     :as mfd]
             [taoensso.tufte        :as tufte]
             [triangulum.logging    :refer [log log-str]]))
 
@@ -15,9 +16,12 @@
 
 (defn write-outputs!
   [outputs]
-  (outputs/write-landfire-layers! outputs)
-  (outputs/write-aggregate-layers! outputs)
-  (outputs/write-csv-outputs! outputs)
+  (->
+    (mfd/zip
+      (outputs/write-landfire-layers! outputs)
+      (outputs/write-aggregate-layers! outputs)
+      (outputs/write-csv-outputs! outputs))
+    (deref))
   :success)
 
 ;; TODO: Disable this to see how much performance is gained.

--- a/src/gridfire/outputs.clj
+++ b/src/gridfire/outputs.clj
@@ -1,10 +1,12 @@
 (ns gridfire.outputs
-  (:require [clojure.core.matrix :as m]
-            [clojure.data.csv    :as csv]
-            [clojure.java.io     :as io]
-            [clojure.string      :as str]
-            [magellan.core       :refer [matrix-to-raster write-raster]]
-            [matrix-viz.core     :refer [save-matrix-as-png]]))
+  (:require [clojure.core.matrix  :as m]
+            [clojure.data.csv     :as csv]
+            [clojure.java.io      :as io]
+            [clojure.string       :as str]
+            [gridfire.utils.async :as gf-async]
+            [manifold.deferred    :as mfd]
+            [magellan.core        :refer [matrix-to-raster write-raster]]
+            [matrix-viz.core      :refer [save-matrix-as-png]]))
 
 (m/set-current-implementation :vectorz)
 
@@ -16,6 +18,77 @@
     (str/join "_" $)
     (str $ ext)))
 
+(defonce ^:private outputs-writing-exectr*
+  (delay
+    ;; This is expensive to create, hence the (defonce ...) and (delay ...) combination.
+    (let [;; AFAICT our outputs-writing tends to be CPU-bound,
+          ;; hence this choice of parallelism.
+          ;; Benchmarks on 4 cores have shown an only-2x performance enhancement,
+          ;; so there might be some contention at play here,
+          ;; and the optimal parallelism might be even lower.
+          writing-parallelism (.availableProcessors (Runtime/getRuntime))]
+      (gf-async/executor-with-n-named-threads
+        "gridfire-outputs-writing"
+        writing-parallelism
+        {:onto? true}))))
+
+(defn outputs-writing-executor
+  "(Advanced) returns the pool of worker Java Threads dedicated to writing GridFire outputs.
+
+   This enables us to parallelize the outputs-writing work (improving throughput)
+   while controlling the degree of parallelism,
+   and making it easy to monitor,
+   as well as straightforward to orchestrate without blocking threads,
+   thanks to the Manifold library.
+
+   To achieve this, the heavy-lifting of output-writing
+   must be done in tasks scheduled into this pool by calling
+   (exec-in-outputs-writing-pool ...)"
+  []
+  @outputs-writing-exectr*)
+
+;; Most of the following functions return either nil or Manifold Deferred,
+;; resolved to nil upon completion of the function's side-effects,
+;; so that they can easily be run in parallel,
+;; and coordinated with minimal thread-blocking.
+;; Manifold DeferredS are semantically equivalent to Promises in other languages;
+;; using them makes async flow control straightforward to implement,
+;; while reaping the benefits of parallelizing
+;; into well-instrumented Thread pools without blocking threads.
+;; Manifold was chosen because it is battle-tested, expressive,
+;; well-suited to this sort of 'hierarchical' async flow control,
+;; and offers good facilities for controlling thread pools.
+;; It is harder to achieve these benefits cleanly by using core.async channels,
+;; which force you into a side-effectful programming model,
+;; and offer little opportunities for fine-tuning;
+;; that said, Manifold is easy to compose with core.async,
+;; which is interesting if you want to benefit from its (go ...) primitive.
+
+(defn exec-in-outputs-writing-pool
+  "Schedules the given 0-arg function to be executed in the thread pool
+  dedicated to GridFire outputs-writing.
+
+  Returns a Manifold Deferred, which will be completed with the return
+  value of f.
+
+  The function f may itself return a Manifold Deferred."
+  [f]
+  (letfn [(run-output-task []
+            ;; Wrapping in a named fn makes it easy to spot in stacktraces,
+            ;; thread dumps, flame graphs etc.
+            (f))]
+    (->
+      (mfd/future-with (outputs-writing-executor)
+        (run-output-task))
+      ;; To advanced users: this helps ensure that (mfd/chain ...) callbacks
+      ;; attached to this Deferred will execute in the same pool.
+      ;; Even with that, it's not guaranteed to happen that way,
+      ;; in situations where (f) executes so fast that this Deferred
+      ;; gets completed even before the mfd/chain function is invoked:
+      ;; in such cases, the callback will execute in the Thread invoking mfd/chain.
+      ;; When it doubt: call (exec-in-outputs-writing-pool ...) again inside your callback.
+      (mfd/onto (outputs-writing-executor)))))
+
 (defn output-geotiff
   ([config matrix name envelope]
    (output-geotiff config matrix name envelope nil nil))
@@ -25,15 +98,17 @@
 
   ([{:keys [output-directory outfile-suffix] :as config}
     matrix name envelope simulation-id output-time]
-   (let [file-name (output-filename name
-                                    outfile-suffix
-                                    (str simulation-id)
-                                    output-time
-                                    ".tif")]
-     (-> (matrix-to-raster name matrix envelope)
-         (write-raster (if output-directory
-                         (str/join "/" [output-directory file-name])
-                         file-name))))))
+   (exec-in-outputs-writing-pool
+     (fn []
+       (let [file-name (output-filename name
+                         outfile-suffix
+                         (str simulation-id)
+                         output-time
+                         ".tif")]
+         (-> (matrix-to-raster name matrix envelope)
+             (write-raster (if output-directory
+                             (str/join "/" [output-directory file-name])
+                             file-name))))))))
 
 (defn output-png
   ([config matrix name envelope]
@@ -44,38 +119,61 @@
 
   ([{:keys [output-directory outfile-suffix]}
     matrix name envelope simulation-id output-time]
-   (let [file-name (output-filename name
-                                    outfile-suffix
-                                    (str simulation-id)
-                                    output-time
-                                    ".png")]
-     (save-matrix-as-png :color 4 -1.0
-                         matrix
-                         (if output-directory
-                           (str/join "/" [output-directory file-name])
-                           (file-name))))))
+   (exec-in-outputs-writing-pool
+     (fn []
+       (let [file-name (output-filename name
+                         outfile-suffix
+                         (str simulation-id)
+                         output-time
+                         ".png")]
+         (save-matrix-as-png :color 4 -1.0
+           matrix
+           (if output-directory
+             (str/join "/" [output-directory file-name])
+             (file-name))))))))
 
 (defn write-landfire-layers!
   [{:keys [output-landfire-inputs? outfile-suffix landfire-rasters envelope]}]
   (when output-landfire-inputs?
-    (doseq [[layer matrix] landfire-rasters]
-      (-> (matrix-to-raster (name layer) matrix envelope)
-          (write-raster (str (name layer) outfile-suffix ".tif"))))))
+    (->> landfire-rasters
+         (mapv
+           (fn [[layer matrix]]
+             (exec-in-outputs-writing-pool
+               (fn []
+                 (-> (matrix-to-raster (name layer) matrix envelope)
+                     (write-raster (str (name layer) outfile-suffix ".tif"))))))))))
 
 (defn write-burn-probability-layer!
   [{:keys [output-burn-probability simulations envelope output-pngs? burn-count-matrix] :as outputs}]
   (when-let [timestep output-burn-probability]
     (let [output-name "burn_probability"]
       (if (int? timestep)
-        (doseq [[band matrix] (map-indexed vector burn-count-matrix)]
-          (let [output-time        (* band timestep)
-                probability-matrix (m/emap #(/ % simulations) matrix)]
-            (output-geotiff outputs probability-matrix output-name envelope nil output-time)
-            (output-png outputs probability-matrix output-name envelope nil output-time)))
-        (let [probability-matrix (m/emap #(/ % simulations) burn-count-matrix)]
-          (output-geotiff outputs probability-matrix output-name envelope)
-          (when output-pngs?
-            (output-png outputs probability-matrix output-name envelope)))))))
+        (->> (map-indexed vector burn-count-matrix)
+             (mapv
+               (fn [[band matrix]]
+                 (->
+                   (exec-in-outputs-writing-pool
+                     (fn []
+                       (let [output-time        (* band timestep)
+                             probability-matrix (m/emap #(/ % simulations) matrix)]
+                         [output-time probability-matrix])))
+                   (mfd/chain
+                     (fn [[output-time probability-matrix]]
+                       (mfd/zip
+                         (output-geotiff outputs probability-matrix output-name envelope nil output-time)
+                         (output-png outputs probability-matrix output-name envelope nil output-time)))))))
+             (gf-async/nil-when-all-completed))
+        (->
+          (exec-in-outputs-writing-pool
+            (fn []
+              (m/emap #(/ % simulations) burn-count-matrix)))
+          (mfd/chain
+            (fn [probability-matrix]
+              (mfd/zip
+                (output-geotiff outputs probability-matrix output-name envelope)
+                (when output-pngs?
+                  (output-png outputs probability-matrix output-name envelope)))))
+          (gf-async/nil-when-completed))))))
 
 (defn write-flame-length-sum-layer!
   [{:keys [envelope output-flame-length-sum? flame-length-sum-matrix] :as outputs}]
@@ -99,44 +197,48 @@
 
 (defn write-aggregate-layers!
   [outputs]
-  (write-burn-probability-layer! outputs)
-  (write-flame-length-sum-layer! outputs)
-  (write-flame-length-max-layer! outputs)
-  (write-burn-count-layer! outputs)
-  (write-spot-count-layer! outputs))
+  (->>
+    [(write-burn-probability-layer! outputs)
+     (write-flame-length-sum-layer! outputs)
+     (write-flame-length-max-layer! outputs)
+     (write-burn-count-layer! outputs)
+     (write-spot-count-layer! outputs)]
+    (gf-async/nil-when-all-completed)))
 
 (defn write-csv-outputs!
   [{:keys [output-csvs? output-directory outfile-suffix summary-stats]}]
   (when output-csvs?
-    (let [output-filename (str "summary_stats" outfile-suffix ".csv")]
-      (with-open [out-file (io/writer (if output-directory
-                                        (str/join "/" [output-directory output-filename])
-                                        output-filename))]
-        (->> summary-stats
-             (sort-by #(vector (:ignition-row %) (:ignition-col %)))
-             (mapv (fn [{:keys [ignition-row ignition-col max-runtime temperature relative-humidity
-                                wind-speed-20ft wind-from-direction foliar-moisture ellipse-adjustment-factor
-                                fire-size flame-length-mean flame-length-stddev fire-line-intensity-mean
-                                fire-line-intensity-stddev simulation crown-fire-size spot-count]}]
-                     [simulation
-                      ignition-row
-                      ignition-col
-                      max-runtime
-                      temperature
-                      relative-humidity
-                      wind-speed-20ft
-                      wind-from-direction
-                      foliar-moisture
-                      ellipse-adjustment-factor
-                      fire-size
-                      flame-length-mean
-                      flame-length-stddev
-                      fire-line-intensity-mean
-                      fire-line-intensity-stddev
-                      crown-fire-size
-                      spot-count]))
-             (cons ["simulation" "ignition-row" "ignition-col" "max-runtime" "temperature" "relative-humidity"
-                    "wind-speed-20ft" "wind-from-direction" "foliar-moisture" "ellipse-adjustment-factor"
-                    "fire-size" "flame-length-mean" "flame-length-stddev" "fire-line-intensity-mean"
-                    "fire-line-intensity-stddev" "crown-fire-size" "spot-count"])
-             (csv/write-csv out-file))))))
+    (exec-in-outputs-writing-pool
+      (fn []
+        (let [output-filename (str "summary_stats" outfile-suffix ".csv")]
+          (with-open [out-file (io/writer (if output-directory
+                                            (str/join "/" [output-directory output-filename])
+                                            output-filename))]
+            (->> summary-stats
+                 (sort-by #(vector (:ignition-row %) (:ignition-col %)))
+                 (mapv (fn [{:keys [ignition-row ignition-col max-runtime temperature relative-humidity
+                                    wind-speed-20ft wind-from-direction foliar-moisture ellipse-adjustment-factor
+                                    fire-size flame-length-mean flame-length-stddev fire-line-intensity-mean
+                                    fire-line-intensity-stddev simulation crown-fire-size spot-count]}]
+                         [simulation
+                          ignition-row
+                          ignition-col
+                          max-runtime
+                          temperature
+                          relative-humidity
+                          wind-speed-20ft
+                          wind-from-direction
+                          foliar-moisture
+                          ellipse-adjustment-factor
+                          fire-size
+                          flame-length-mean
+                          flame-length-stddev
+                          fire-line-intensity-mean
+                          fire-line-intensity-stddev
+                          crown-fire-size
+                          spot-count]))
+                 (cons ["simulation" "ignition-row" "ignition-col" "max-runtime" "temperature" "relative-humidity"
+                        "wind-speed-20ft" "wind-from-direction" "foliar-moisture" "ellipse-adjustment-factor"
+                        "fire-size" "flame-length-mean" "flame-length-stddev" "fire-line-intensity-mean"
+                        "fire-line-intensity-stddev" "crown-fire-size" "spot-count"])
+                 (csv/write-csv out-file))))))))

--- a/src/gridfire/utils/async.clj
+++ b/src/gridfire/utils/async.clj
@@ -1,0 +1,47 @@
+(ns gridfire.utils.async
+  (:require [manifold.deferred :as mfd]
+            [manifold.executor])
+  (:import java.util.concurrent.ExecutorService))
+
+;; ------------------------------------------------------------------------------
+;; Helper fns
+
+(defn nil-when-completed
+  "Returns a Manifold Deferred that will complete when d completes,
+  but be resolved with nil instead of the result of d."
+  [d]
+  (mfd/chain d (constantly nil)))
+
+(defn nil-when-all-completed
+  "Waits for all the given DeferredS to complete, yielding nil.
+  Returns immediately a Deferred, resolved with nil
+  when all the Deferred in ds have completed successfully.
+
+  Useful for awaiting effects scheduled in parallel."
+  [ds]
+  (->> ds
+       (apply mfd/zip)
+       (nil-when-completed)))
+
+;; ------------------------------------------------------------------------------
+;; Executors
+
+(defn executor-with-n-named-threads
+  "Creates a fixed-sized thread pool for executing task.
+  The Java threads will be named after the supplied prefix string."
+  ^ExecutorService
+  [thread-name-prefix n-threads exctr-options]
+  (let [p-exctr (promise)
+        exctr   (manifold.executor/fixed-thread-executor
+                  n-threads
+                  (merge
+                    {:thread-factory (manifold.executor/thread-factory
+                                       (let [next-thread-id* (atom -1)]
+                                         (fn gen-thread-name []
+                                           ;; Naming the threads makes them easy to observe in monitoring
+                                           ;; tools such as VisualVM and jstat.
+                                           (str thread-name-prefix "-" (swap! next-thread-id* inc))))
+                                       p-exctr)}
+                    exctr-options))]
+    (deliver p-exctr exctr)
+    exctr))

--- a/src/my_experiments.clj
+++ b/src/my_experiments.clj
@@ -1,0 +1,34 @@
+(ns my-experiments
+  (:require [gridfire.core]
+            [taoensso.tufte :as tufte]))
+
+
+(require 'clj-async-profiler.core)
+#_(tufte/add-basic-println-handler! {})
+(comment
+  (clj-async-profiler.core/serve-files 8080)
+
+  (->> ...
+       (tufte/p ::write-outputs!))
+
+
+  (tufte/profile {:id ::outputs-benchmark}
+    (dotimes [_ 10]
+      (gridfire.core/process-config-file! "resources/my-gridfire-benchmark-FIXME.edn")))
+
+  ;id: :my-experiments/outputs-benchmark
+  ;pId                               nCalls        Min      50% ≤      90% ≤      95% ≤      99% ≤        Max       Mean   MAD      Clock  Total
+  ;
+  ;:gridfire.core/write-outputs!         10     2.52s      2.63s      2.83s      2.88s      2.88s      2.88s      2.64s    ±3%    26.39s     33%
+  ;
+  ;Accounted                                                                                                                      26.39s     33%
+  ;Clock                                                                                                                           1.35m    100%
+
+  ;id: :my-experiments/outputs-benchmark
+  ;pId                               nCalls        Min      50% ≤      90% ≤      95% ≤      99% ≤        Max       Mean   MAD      Clock  Total
+  ;
+  ;:gridfire.core/write-outputs!         10     1.32s      1.37s      1.47s      1.68s      1.68s      1.68s      1.40s    ±5%    14.01s     20%
+  ;
+  ;Accounted                                                                                                                      14.01s     20%
+  ;Clock                                                                                                                           1.16m    100%
+  *e)


### PR DESCRIPTION
## Purpose
To improve throughput, parallelize outputs-writing.

I accidentally deleted my benchmark results, but in was in the 2X ballpark. We should probably expect this to happen differently in production anyway.

I saw no regressions in unit tests, but please watch out: I had to do some nasty conflict resolution.

**NOTE:** if you want to merge into `development` instead of `main`, use branch [vwaeselynck-353-parallelize-aggregate-layers-writing--development](https://github.com/pyregence/gridfire/tree/vwaeselynck-353-parallelize-aggregate-layers-writing--development), which readily provides conflict resolution: see #73 .

## Related Issues
Closes GRID-353

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

