### PR TITLE
GRID-372 Fix reported suppressed count

### DIFF
--- a/src/gridfire/suppression.clj
+++ b/src/gridfire/suppression.clj
@@ -154,7 +154,7 @@
               slices))]
     (let [angular-slices+avg-dsr->num-cells (compute-contiguous-slices num-cells-to-suppress angular-slice->avg-dsr+num-cells)]
       (loop [remaining-segments angular-slices+avg-dsr->num-cells
-             n-cells-needed     (long num-cells-to-suppress)
+             n-cells-needed     num-cells-to-suppress
              slices-to-suppress #{}]
         (if-some [segment (when (pos? n-cells-needed)
                             (first remaining-segments))]


### PR DESCRIPTION
## Purpose
Fixed incorrect suppressed-count returned by gridfire.suppression/compute-slices-to-suppress, which caused over-estimated suppression.

Even if this fix may seem suboptimal, e.g wrt performance, I'd still recommend deploying it ASAP - arguably, lack of correctness in production is a more urgent problem than lack of performance.

## Related Issues
Closes GRID-372

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

