### PR TITLE
Fix to color-map-values boolean check #review GRID-374

### DIFF
--- a/src/gridfire/simulations.clj
+++ b/src/gridfire/simulations.clj
@@ -63,7 +63,7 @@
              (->
                (outputs/exec-in-outputs-writing-pool
                  (fn []
-                   (let [matrix (if (= layer "burn_history")
+                   (let [matrix (if (= name "burn_history")
                                   (to-color-map-values layer output-time)
                                   (fire-spread-results layer))]
                      (layer-snapshot burn-time-matrix matrix output-time))))


### PR DESCRIPTION
## Purpose
Bug in time-stepped outputs-writing logic for burn_history.

## Related Issues
Closes GRID-374

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

No regression in unit tests.