### PR TITLE
GRID-370 add default weather-start-timestamp

### DIFF
--- a/src/gridfire/inputs.clj
+++ b/src/gridfire/inputs.clj
@@ -296,7 +296,7 @@
 
 (defn add-ignition-start-timestamps
   [{:keys [ignition-start-times simulations ignition-start-timestamp weather-start-timestamp] :as inputs}]
-  (let [weather-start-ms                 (inst-ms weather-start-timestamp)
+  (let [weather-start-ms                 (inst-ms (or weather-start-timestamp #inst "1970-01-01T00-00:00"))
         compute-ignition-start-timestamp (fn [ignition-start-time]
                                            (Date. (+ weather-start-ms (min->ms ignition-start-time))))
         ignition-start-timestamps        (cond


### PR DESCRIPTION
-------

## Purpose
weather-start-timestamp needs a default value so old config without this key can still work.

## Related Issues
Closes GRID-370

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)