### PR TITLE
GRID1-349 Read ignition pyrome from fire_size_stats.csv into ignitions.csv

### DIFF
--- a/resources/elm_to_grid.clj
+++ b/resources/elm_to_grid.clj
@@ -370,6 +370,20 @@
                                 :source (file-path output-dir WEATHER_DIRECTORY "mlh")})}}))
 
 ;;=============================================================================
+;; Pyrome specific calibration
+;;=============================================================================
+
+(defn process-pyrome-specific-calibration
+  [{:strs [ADJUSTMENT_FACTORS_BY_PYROME CALIBRATION_CONSTANTS_BY_PYROME ADJUSTMENT_FACTORS_FILENAME
+           CALIBRATION_CONSTANTS_FILENAME]}
+   config]
+  (cond-> config
+    (true? ADJUSTMENT_FACTORS_BY_PYROME)    (assoc :pyrome-spread-rate-adjustment-csv
+                                                   ADJUSTMENT_FACTORS_FILENAME)
+    (true? CALIBRATION_CONSTANTS_BY_PYROME) (assoc :pyrome-calibration-csv
+                                                   CALIBRATION_CONSTANTS_FILENAME)))
+
+;;=============================================================================
 ;; Build gridfire.edn
 ;;=============================================================================
 
@@ -391,7 +405,8 @@
        (process-output options data)
        (process-perturbations data)
        (process-spotting data)
-       (process-fuel-moisture options data)))
+       (process-fuel-moisture options data)
+       (process-pyrome-specific-calibration data)))
 
 ;;=============================================================================
 ;; Parse elmfire.data

--- a/test/gridfire/inputs_test.clj
+++ b/test/gridfire/inputs_test.clj
@@ -97,3 +97,15 @@
     (is (not-empty (get-in inputs-after [:suppression :sdi-sensitivity-to-difficulty])))
     (is (not-empty (get-in inputs-after [:suppression :sdi-containment-overwhelming-area-growth-rate])))
     (is (not-empty (get-in inputs-after [:suppression :sdi-reference-suppression-speed])))))
+
+(deftest add-ignition-csv-test
+  (let [inputs       {:ignition-csv "test/gridfire/resources/sample_ignitions.csv"}
+        inputs-after (inputs/add-ignition-csv inputs)]
+    (is (= {:ignition-csv         "test/gridfire/resources/sample_ignitions.csv"
+            :ignition-rows        [4 5 6]
+            :ignition-cols        [1 2 3]
+            :ignition-start-times [0.0 0.0 0.0]
+            :max-runtime-samples  [10.0 20.0 30.0]
+            :pyromes              [7 7 7]
+            :simulations          3}
+           inputs-after))))

--- a/test/gridfire/resources/sample_ignitions.csv
+++ b/test/gridfire/resources/sample_ignitions.csv
@@ -1,4 +1,4 @@
-row,col,start_time(min),max_runtime(min)
-4,1,0,10
-5,2,0,20
-6,3,0,30
+ignition-row,ignition-col,ignition-start-time (min),max-runtime (min),pyrome
+4,1,0,10,7
+5,2,0,20,7
+6,3,0,30,7


### PR DESCRIPTION
-------

## Purpose
- Update parsing of fire_size_stats.csv to include pyrome
- reworked parsing of ignitions csv for better readability
- update elm_to_grid to also add file paths of pyrome specific csvs as specified in elmfire.data
- Add test for inputs/add-ignition-csv

## Related Issues
Closes GRID1-349

## Testing
- run tests in gridfire.inputs-test