### PR TITLE
Fixed suppression to keep fraction-contained >= 0.

### DIFF
--- a/src/gridfire/suppression.clj
+++ b/src/gridfire/suppression.clj
@@ -311,7 +311,7 @@
                                                              suppression-difficulty-factor)
                                                           (percent->dec)
                                                           (* (min->day suppression-dt)))]
-    (+ previous-fraction-contained change-in-fraction-contained)))
+    (max 0.0 (+ previous-fraction-contained change-in-fraction-contained))))
 
 (defn- compute-fraction-contained-sc
   "Compute fraction contained using suppression curve algorithm"


### PR DESCRIPTION
## Purpose
Fixes suppression bug in computation of next fraction-contained.

## Related Issues
Closes GRID-###

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [ ] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given..., When ..., Then ....

## Screenshots
<!-- Add a screen shot when UI changes are included -->

