### PR TITLE
GRID1-391 Update elmtogrid.clj to translate fuel varying spotting params

### DIFF
--- a/resources/elm_to_grid.clj
+++ b/resources/elm_to_grid.clj
@@ -41,7 +41,7 @@
 
 (defn extract-fuel-range
   "Given elmfire key parse lower and upper bound of fuel-number
-  values. If lower and/or upper bound is not specified us given
+  values. If lower and/or upper bound is not specified use the given
   default values [L H]."
   [s L+H]
   (let [[L H]    L+H


### PR DESCRIPTION
-------

## Purpose
- Added support for parsing CRITICAL_SPOTTING_FIRELINE_INTENSITY(x:y)

```
CRITICAL_SPOTTING_FIRELINE_INTENSITY(0:256) = 1200.0
CRITICAL_SPOTTING_FIRELINE_INTENSITY(257:)  = 100.0
```

- Also current elmfire.data in
/home/elmfire/elmfire/runs/annual_burnprob/calibration/53 don't
actually use CRITICAL_SPOTTING_FIRELINE_INTENSITY anymore so it will
default to 0.0. This was the main reason elm_to_grid.clj failed on the
test runs on Gaia using the new launch.org scripts.

- Fixed some branching logic for spotting parameters

- Added support fuel-varying multipliers for spot parameters.
```
SURFACE_FIRE_SPOTTING_PERCENT_MULT(211:)    = 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
```
  - this introduces a new key
    `:fuel-number->surface-spotting-percent-multiplier` in the config
    under the path `[:spotting :surface-fire-spotting]`


## Related Issues
Closes GRID-391

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)