### PR TITLE
GRID1-409: update spec for new fuel varying spotting params

### DIFF
--- a/src/gridfire/spec/config.clj
+++ b/src/gridfire/spec/config.clj
@@ -148,10 +148,10 @@
 
 (s/def ::valid-fuel-range             (fn [[lo hi]] (< 0 lo hi 205)))
 (s/def ::fuel-number-range            (s/and ::common/integer-range ::valid-fuel-range))
-(s/def ::fuel-percent-pair            (s/tuple ::fuel-number-range ::common/float-or-range))
-(s/def ::spotting-percent             (s/coll-of ::fuel-percent-pair :kind vector?))
+(s/def ::fuel-range+number            (s/tuple ::fuel-number-range ::common/float-or-range))
+(s/def ::spotting-percent             (s/coll-of ::fuel-range+number :kind vector?))
 (s/def ::critical-fire-line-intensity (s/or :number            number?
-                                            :fuel-percent-pair (s/coll-of ::fuel-percent-pair :kind vector?)))
+                                            :fuel-percent-pair (s/coll-of ::fuel-range+number :kind vector?)))
 
 (s/def ::surface-fire-spotting
   (s/keys :req-un [::spotting-percent


### PR DESCRIPTION
-------

## Purpose
- Update spec for `critical-fire-line-intensity`. This should support fuel-ranges like `spotting-percent`

## Related Issues
Closes GRID-409

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)