### PR TITLE
Disable performance logging by default

### DIFF
--- a/src/gridfire/core.clj
+++ b/src/gridfire/core.clj
@@ -29,10 +29,12 @@
   `(do (tufte/remove-handler! :accumulating)
        (let [stats-accumulator# (tufte/add-accumulating-handler! {:handler-id :accumulating})
              result#            (do ~@body)]
-         (Thread/sleep 1000)
+         (when simulations/*log-performance-metrics*
+           (Thread/sleep 1000))
          (as-> {:format-pstats-opts {:columns [:n-calls :min :max :mean :mad :clock :total]}} $#
            (tufte/format-grouped-pstats @stats-accumulator# $#)
-           (log $# :truncate? false))
+           (when simulations/*log-performance-metrics*
+             (log $# :truncate? false)))
          result#)))
 
 (defn run-simulations!

--- a/src/gridfire/simulations.clj
+++ b/src/gridfire/simulations.clj
@@ -16,6 +16,15 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
+(def ^:dynamic *log-performance-metrics*
+  "Whether to log performance monitoring metrics,
+  which adds latency to simulations,
+  and verbosity to the logs."
+  (= "true"
+     ;; TIP: to re-def this Var as true in your REPL,
+     ;; comment out the following expr and reload the code, using #_
+     (System/getProperty "gridfire.simulations.log-performance-metrics")))
+
 (defn layer-snapshot [burn-time-matrix layer-matrix ^double t]
   (d/clone
    (d/emap (fn [^double layer-value ^double burn-time]


### PR DESCRIPTION
## Purpose
We usually don't need the performance logs, which add latency and verbosity that dilutes the testing output.

This PR makes the **performance logging disabled by default,** but settable at 2 levels: 
1. the Java property `gridfire.simulations.log-performance-metrics`
2. the dynamic Var `gridfire.simulations/*log-performance-metrics*`

## Related Issues
None.

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing

`clojure -J-Dgridfire.simulations.log-performance-metrics=true -M:test --include :simulation`

`clojure -M:test --include :simulation`

