### PR TITLE
GRID1-434 Compiler options for production jar #review

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -33,6 +33,7 @@
 
   (b/compile-clj {:src-dirs     ["src"]
                   :class-dir    jar-content
+                  :bindings     {#'clojure.core/*assert* false}
                   :compile-opts {:direct-linking true}
                   :basis        basis})
 


### PR DESCRIPTION
## Purpose
Make production runs faster via Clojure compilation options **(direct linking, disabled asserts)**.

## Related Issues
Closes GRID1-434

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing

I tested by manually creating the uberjar, running it on the AWS input deck, and observing successful execution:

```
vwaeselynck@iiwi:~/gridfire$ clojure -T:build uberjar
Downloading: org/eclipse/emf/org.eclipse.emf.ecore/maven-metadata.xml from central
Downloading: org/eclipse/emf/org.eclipse.emf.common/maven-metadata.xml from central
Build folder "target" removed
Uberjar file created: "target/gridfire-2022.11.21-6bdbb34.jar"
vwaeselynck@iiwi:~/gridfire$ java -XX:MaxRAMPercentage=75 -jar target/gridfire-2022.11.21-6bdbb34.jar ../ff_aws_input_data/gridfire.edn 
gridfire: Launch fire spread simulations via config files or in server mode.
Copyright © 2014-2022 Spatial Informatics Group, LLC.

11/21 13:51:07 Running simulations
```

