### PR TITLE
Drop geotiff-raster-to-matrix

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3695,7 +3695,7 @@ command line interface.
 ** Magellan
 
 Reading raster layers from disk is performed by a single function,
-called *geotiff-raster-to-matrix*. Given the location of a GeoTIFF
+called *geotiff-raster-to-tensor*. Given the location of a GeoTIFF
 file, this function will read the raster into memory and return the
 same map of information as the *postgis-raster-to-matrix* function,
 described in the previous section.
@@ -3713,42 +3713,6 @@ described in the previous section.
 
 (defn register-custom-projections! []
   (register-new-crs-definitions-from-properties-file! "CUSTOM" (io/resource "custom_projections.properties")))
-
-(defn geotiff-raster-to-matrix
-  "Reads a raster from a file using the magellan.core library. Returns the
-   post-processed raster values as a Clojure tensor using the dtype-next/tech.v3.tensor API
-   along with all of the georeferencing information associated with this tile in a
-   hash-map with the following form:
-  {:srid 900916,
-   :upperleftx -321043.875,
-   :upperlefty -1917341.5,
-   :width 486,
-   :height 534,
-   :scalex 2000.0,
-   :scaley -2000.0,
-   :skewx 0.0,
-   :skewy 0.0,
-   :numbands 10,
-   :matrix #tech.v3.tensor<datatype>[10 534 486]}"
-  [file-path]
-  (let [raster   (read-raster file-path)
-        grid     ^GridGeometry2D (:grid raster)
-        r-info   (inspect/describe-raster raster)
-        matrix   (inspect/extract-matrix raster)
-        image    (:image r-info)
-        envelope (:envelope r-info)
-        crs2d    ^AffineTransform2D (.getGridToCRS2D grid)]
-    {:srid       (:srid r-info)
-     :upperleftx (get-in envelope [:x :min])
-     :upperlefty (get-in envelope [:y :max])
-     :width      (:width image)
-     :height     (:height image)
-     :scalex     (.getScaleX crs2d)
-     :scaley     (.getScaleY crs2d)
-     :skewx      0.0 ; FIXME not used?
-     :skewy      0.0 ; FIXME not used?
-     :numbands   (:bands image)
-     :matrix     (t/->tensor matrix)}))
 
 (defn geotiff-raster-to-tensor
   "Reads a raster from a file using the magellan.core library. Returns the

--- a/src/gridfire/magellan_bridge.clj
+++ b/src/gridfire/magellan_bridge.clj
@@ -12,42 +12,6 @@
 (defn register-custom-projections! []
   (register-new-crs-definitions-from-properties-file! "CUSTOM" (io/resource "custom_projections.properties")))
 
-(defn geotiff-raster-to-matrix
-  "Reads a raster from a file using the magellan.core library. Returns the
-   post-processed raster values as a Clojure tensor using the dtype-next/tech.v3.tensor API
-   along with all of the georeferencing information associated with this tile in a
-   hash-map with the following form:
-  {:srid 900916,
-   :upperleftx -321043.875,
-   :upperlefty -1917341.5,
-   :width 486,
-   :height 534,
-   :scalex 2000.0,
-   :scaley -2000.0,
-   :skewx 0.0,
-   :skewy 0.0,
-   :numbands 10,
-   :matrix #tech.v3.tensor<datatype>[10 534 486]}"
-  [file-path]
-  (let [raster   (read-raster file-path)
-        grid     ^GridGeometry2D (:grid raster)
-        r-info   (inspect/describe-raster raster)
-        matrix   (inspect/extract-matrix raster)
-        image    (:image r-info)
-        envelope (:envelope r-info)
-        crs2d    ^AffineTransform2D (.getGridToCRS2D grid)]
-    {:srid       (:srid r-info)
-     :upperleftx (get-in envelope [:x :min])
-     :upperlefty (get-in envelope [:y :max])
-     :width      (:width image)
-     :height     (:height image)
-     :scalex     (.getScaleX crs2d)
-     :scaley     (.getScaleY crs2d)
-     :skewx      0.0 ; FIXME not used?
-     :skewy      0.0 ; FIXME not used?
-     :numbands   (:bands image)
-     :matrix     (t/->tensor matrix)}))
-
 (defn geotiff-raster-to-tensor
   "Reads a raster from a file using the magellan.core library. Returns the
    post-processed raster values as a Clojure tensor using the dtype-next/tech.v3.tensor API

--- a/test/gridfire/fetch_fuel_moisture_test.clj
+++ b/test/gridfire/fetch_fuel_moisture_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test                :refer [deftest are]]
    [gridfire.fetch              :as fetch]
-   [gridfire.magellan-bridge    :refer [geotiff-raster-to-matrix]]
+   [gridfire.magellan-bridge    :refer [geotiff-raster-to-tensor]]
    [gridfire.utils.test         :as utils]
    [gridfire.conversion         :as convert]
    [tech.v3.datatype            :as d]
@@ -13,7 +13,7 @@
 (defn- equal-matrix?
   [inputs category size]
   (let [matrix (-> (get-in inputs [:fuel-moisture category size :source])
-                   geotiff-raster-to-matrix
+                   geotiff-raster-to-tensor
                    :matrix)]
     (dfn/equals (:matrix (fetch/fuel-moisture-layer inputs category size))
                 (d/clone (d/emap convert/percent->dec nil matrix)))))
@@ -37,3 +37,7 @@
       :dead :100hr
       :live :herbaceous
       :live :woody)))
+(comment
+  (clojure.test/test-vars [#'fuel-moisture-test])
+
+  *e)


### PR DESCRIPTION
## Purpose
As discussed in our last GridFire Sprint Planning, this is dead code to be eliminated.

