### PR TITLE
Temporarily updated Magellan dep to Git coordinates.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
         org.clojure/java.jdbc               {:mvn/version "0.7.12"}
         org.clojure/tools.cli               {:mvn/version "1.0.206"}
         org.postgresql/postgresql           {:mvn/version "42.2.23"}
-        sig-gis/magellan                    {:mvn/version "2022.10.21"}
+        sig-gis/magellan                    {:git/url "https://github.com/sig-gis/magellan" :sha "6730285f033704dd9cd863535aaf94b11a352f5a"} ;{:mvn/version "2022.10.21"} ;; TODO restore to a tagged version when published. (Val, 19 Dec 2022)
         sig-gis/triangulum                  {:git/url "https://github.com/sig-gis/triangulum"
                                              :sha     "5b179a97ebd8fbcbff51776db06d9770cb649b9d"}}
 


### PR DESCRIPTION
## Purpose
Git coordinates for the recent Magellan update, for lack of a tagged version deployed to Clojars.


