### PR TITLE
(catch Exception ...) -> (catch Throwable ...) to catch more issues like OutOfMemoryError.

### DIFF
--- a/src/gridfire/server/run_config.clj
+++ b/src/gridfire/server/run_config.clj
@@ -45,7 +45,7 @@
       (mfd/success! completion-dfr
                     ;; This map might get enriched in the future. (Val, 11 Jan 2023)
                     {}))
-    (catch Exception err
+    (catch Throwable err
       (mfd/error! completion-dfr err))))
 
 (defn start-run-config-handler!

--- a/src/gridfire/server/sync.clj
+++ b/src/gridfire/server/sync.clj
@@ -58,10 +58,10 @@
     (try
       (let [success-data @completion-dfr]
         (into {:gridfire.run-config/succeeded true} success-data))
-      (catch Exception err
+      (catch Throwable err
         (let [err-map (or (try
                             (Throwable->map err)
-                            (catch Exception _parsing-err nil))
+                            (catch Throwable _parsing-err nil))
                           {:message (str "(FAILED Throwable->map) " (ex-message err))})]
           {:gridfire.run-config/succeeded  false
            :gridfire.run-config/error-data err-map})))))
@@ -79,7 +79,7 @@
   (map (fn edn-encode-safe [res]
          (try
            (pr-str res)
-           (catch Exception err
+           (catch Throwable err
              (pr-str (tagged-literal 'gridfire.server.sync/failed-printing-result
                                      {::ex-class-name (.getName (class err))
                                       ::ex-message    (ex-message err)})))))))

--- a/src/gridfire/utils/async.clj
+++ b/src/gridfire/utils/async.clj
@@ -74,7 +74,7 @@
                                       (try
                                         (mfd/success! d
                                                       (f x))
-                                        (catch Exception err
+                                        (catch Throwable err
                                           (mfd/error! d err)))
                                       d))
                                =tasks=)

--- a/src/gridfire/utils/server.clj
+++ b/src/gridfire/utils/server.clj
@@ -12,7 +12,7 @@
 (defmacro nil-on-error
   [& body]
   (let [_ (gensym)]
-    `(try ~@body (catch Exception ~_ nil))))
+    `(try ~@body (catch Throwable ~_ nil))))
 
 (defn non-empty-string?
   [x]


### PR DESCRIPTION
## Purpose
(Hopefully) fixes OutOfMemoryError and the like not being handled in some try/catch clauses, because they do not inherit from java.lang.Exception.
