### PR TITLE
More efficient layer-snapshot #GRID1-551

### DIFF
--- a/src/gridfire/outputs.clj
+++ b/src/gridfire/outputs.clj
@@ -4,7 +4,7 @@
             [clojure.java.io      :as io]
             [clojure.string       :as str]
             [gridfire.utils.async :as gf-async]
-            [magellan.core        :refer [matrix-to-raster write-raster]]
+            [magellan.core        :refer [float-2d-array-to-raster matrix-to-raster write-raster]]
             [manifold.deferred    :as mfd]
             [matrix-viz.core      :refer [save-matrix-as-png]]
             [tech.v3.datatype     :as d]))
@@ -107,6 +107,20 @@
                                    output-time
                                    ".tif")]
     (-> (matrix-to-raster name matrix envelope)
+        (write-raster (if output-directory
+                        (str/join "/" [output-directory file-name])
+                        file-name)))))
+
+(defn output-geotiff-from-float2darr
+  [{:keys [output-directory outfile-suffix] :as _config}
+   ^"[[F" float2darr
+   name envelope simulation-id output-time]
+  (let [file-name (output-filename name
+                                   outfile-suffix
+                                   (str simulation-id)
+                                   output-time
+                                   ".tif")]
+    (-> (float-2d-array-to-raster name float2darr envelope)
         (write-raster (if output-directory
                         (str/join "/" [output-directory file-name])
                         file-name)))))

--- a/src/gridfire/outputs.clj
+++ b/src/gridfire/outputs.clj
@@ -98,6 +98,19 @@
       ;; When it doubt: call (exec-in-outputs-writing-pool ...) again inside your callback.
       (mfd/onto (outputs-writing-executor)))))
 
+(defn output-geotiff-sync
+  [{:keys [output-directory outfile-suffix] :as _config}
+   matrix name envelope simulation-id output-time]
+  (let [file-name (output-filename name
+                                   outfile-suffix
+                                   (str simulation-id)
+                                   output-time
+                                   ".tif")]
+    (-> (matrix-to-raster name matrix envelope)
+        (write-raster (if output-directory
+                        (str/join "/" [output-directory file-name])
+                        file-name)))))
+
 (defn output-geotiff
   ([config matrix name envelope]
    (output-geotiff config matrix name envelope nil nil))
@@ -105,19 +118,24 @@
   ([config matrix name envelope simulation-id]
    (output-geotiff config matrix name envelope simulation-id nil))
 
-  ([{:keys [output-directory outfile-suffix] :as config}
-    matrix name envelope simulation-id output-time]
+  ([config matrix name envelope simulation-id output-time]
    (exec-in-outputs-writing-pool
      (fn []
-       (let [file-name (output-filename name
-                                        outfile-suffix
-                                        (str simulation-id)
-                                        output-time
-                                        ".tif")]
-         (-> (matrix-to-raster name matrix envelope)
-             (write-raster (if output-directory
-                             (str/join "/" [output-directory file-name])
-                             file-name))))))))
+       (output-geotiff-sync config matrix name envelope simulation-id output-time)))))
+
+(defn output-png-sync
+  [{:keys [output-directory outfile-suffix]}
+   matrix name simulation-id output-time]
+  (let [file-name (output-filename name
+                                   outfile-suffix
+                                   (str simulation-id)
+                                   output-time
+                                   ".png")]
+    (save-matrix-as-png :color 4 -1.0
+                        matrix
+                        (if output-directory
+                          (str/join "/" [output-directory file-name])
+                          (file-name)))))
 
 (defn output-png
   ([config matrix name envelope]
@@ -126,20 +144,10 @@
   ([config matrix name envelope simulation-id]
    (output-png config matrix name envelope simulation-id nil))
 
-  ([{:keys [output-directory outfile-suffix]}
-    matrix name envelope simulation-id output-time]
+  ([config matrix name _envelope simulation-id output-time]
    (exec-in-outputs-writing-pool
      (fn []
-       (let [file-name (output-filename name
-                                        outfile-suffix
-                                        (str simulation-id)
-                                        output-time
-                                        ".png")]
-         (save-matrix-as-png :color 4 -1.0
-                             matrix
-                             (if output-directory
-                               (str/join "/" [output-directory file-name])
-                               (file-name))))))))
+       (output-png-sync config matrix name simulation-id output-time)))))
 
 (defn write-landfire-layers!
   [{:keys [output-landfire-inputs? outfile-suffix landfire-rasters envelope]}]
@@ -170,24 +178,17 @@
                     (fn []
                       (let [output-time        (* (long band) timestep)
                             probability-matrix (d/clone (d/emap div-by-simulations nil matrix))]
-                        [output-time probability-matrix])))
-                   (mfd/chain
-                    (fn [[output-time probability-matrix]]
-                      (mfd/zip
-                       (output-geotiff outputs probability-matrix output-name envelope nil output-time)
-                       (when output-pngs?
-                         (output-png outputs probability-matrix output-name envelope nil output-time))))))))
+                        (output-geotiff-sync outputs probability-matrix output-name envelope nil output-time)
+                        (when output-pngs?
+                          (output-png-sync outputs probability-matrix output-name nil output-time))))))))
                (gf-async/nil-when-all-completed)))
         (->
          (exec-in-outputs-writing-pool
           (fn []
-            (d/clone (d/emap div-by-simulations nil burn-count-matrix))))
-         (mfd/chain
-          (fn [probability-matrix]
-            (mfd/zip
-             (output-geotiff outputs probability-matrix output-name envelope)
-             (when output-pngs?
-               (output-png outputs probability-matrix output-name envelope)))))
+            (let [probability-matrix (d/clone (d/emap div-by-simulations nil burn-count-matrix))]
+              (output-geotiff-sync outputs probability-matrix output-name envelope nil nil)
+              (when output-pngs?
+                (output-png-sync outputs probability-matrix output-name nil nil)))))
          (gf-async/nil-when-completed))))))
 
 (defn write-flame-length-sum-layer!

--- a/src/gridfire/simulations.clj
+++ b/src/gridfire/simulations.clj
@@ -81,14 +81,14 @@
              (->
                (outputs/exec-in-outputs-writing-pool
                  (fn []
-                   (let [matrix          (if (= name "burn_history")
-                                           (to-color-map-values layer output-time)
-                                           (fire-spread-results layer))
-                         filtered-matrix (layer-snapshot burn-time-matrix matrix output-time)]
+                   (let [matrix           (if (= name "burn_history")
+                                            (to-color-map-values layer output-time)
+                                            (fire-spread-results layer))
+                         *filtered-matrix (delay (layer-snapshot burn-time-matrix matrix output-time))]
                      (when output-geotiffs?
-                       (outputs/output-geotiff-sync config filtered-matrix name envelope simulation-id output-time))
+                       (outputs/output-geotiff-sync config (deref *filtered-matrix) name envelope simulation-id output-time))
                      (when output-pngs?
-                       (outputs/output-png-sync config filtered-matrix name simulation-id output-time)))))
+                       (outputs/output-png-sync config (deref *filtered-matrix) name simulation-id output-time)))))
                (gf-async/nil-when-completed))))
          (gf-async/nil-when-all-completed))))
 

--- a/test/gridfire/simulations_test.clj
+++ b/test/gridfire/simulations_test.clj
@@ -1,10 +1,45 @@
 ;; [[file:../../org/GridFire.org::gridfire.simulations-test][gridfire.simulations-test]]
 (ns gridfire.simulations-test
-  (:require [gridfire.grid-lookup :as grid-lookup]
-            [gridfire.simulations :as simulations]
-            [clojure.test :refer [deftest is testing]]
-            [tech.v3.tensor :as t])
+  (:require [gridfire.grid-lookup        :as grid-lookup]
+            [gridfire.simulations        :as simulations]
+            [clojure.test                :refer [deftest is testing]]
+            [tech.v3.datatype.functional :as dfn]
+            [tech.v3.tensor              :as t])
   (:import java.util.Random))
+
+(def example-burn-time-matrix
+  (-> (t/->tensor [[-1.0 -1.0 -1.0]
+                   [-1.0 5.22 -1.0]
+                   [1.33 0.0 -1.0]]
+                  :datatype :float32)
+      (grid-lookup/ensure-flat-jvm-tensor)
+      (grid-lookup/add-double-getter)))
+
+(def example-flame-length-matrix
+  (-> (t/->tensor [[-1.0 -1.0 -1.0]
+                   [-1.0 7.45 -1.0]
+                   [2.45 7.44 -1.0]]
+                  :datatype :float32)
+      (grid-lookup/ensure-flat-jvm-tensor)
+      (grid-lookup/add-double-getter)))
+
+(defn- float2darr->matrix
+  [float2darr]
+  (->> float2darr
+       (seq)
+       (map t/->tensor)
+       (t/->tensor)))
+
+(deftest layer-snapshot-float2darr-test
+  (testing (str `simulations/layer-snapshot-float2darr)
+    (testing (str "yields an result equivalent to " `simulations/layer-snapshot)
+      (is (dfn/equals (simulations/layer-snapshot example-burn-time-matrix
+                                                  example-flame-length-matrix
+                                                  2.0)
+                      (->> (simulations/layer-snapshot-float2darr example-burn-time-matrix
+                                                                  example-flame-length-matrix
+                                                                  2.0)
+                           (float2darr->matrix)))))))
 
 (defn- identical-matrix [band width height value]
   (t/->tensor

--- a/test/gridfire/simulations_test.clj
+++ b/test/gridfire/simulations_test.clj
@@ -3,6 +3,7 @@
   (:require [gridfire.grid-lookup        :as grid-lookup]
             [gridfire.simulations        :as simulations]
             [clojure.test                :refer [deftest is testing]]
+            [tech.v3.datatype            :as d]
             [tech.v3.datatype.functional :as dfn]
             [tech.v3.tensor              :as t])
   (:import java.util.Random))
@@ -39,7 +40,15 @@
                       (->> (simulations/layer-snapshot-float2darr example-burn-time-matrix
                                                                   example-flame-length-matrix
                                                                   2.0)
-                           (float2darr->matrix)))))))
+                           (float2darr->matrix)))))
+    (testing "still works when all rows are null"
+      (is (dfn/equals (->> (simulations/layer-snapshot-float2darr (-> (t/const-tensor -1.0 (d/shape example-flame-length-matrix))
+                                                                      (grid-lookup/ensure-flat-jvm-tensor)
+                                                                      (grid-lookup/add-double-getter))
+                                                                  example-flame-length-matrix
+                                                                  2.0)
+                           (float2darr->matrix))
+                      (t/const-tensor 0.0 (d/shape example-flame-length-matrix)))))))
 
 (defn- identical-matrix [band width height value]
   (t/->tensor


### PR DESCRIPTION
## Purpose
Eliminate unnecessary work in `process-output-layers-timestepped`, which will in particular massively reduce the compute load in PyreCast.

## Related Issues
Closes GRID1-551

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `GRID-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
There's a new test case.

